### PR TITLE
Replace third-party API with official MTA GTFS-RT feeds in Android app

### DIFF
--- a/NowDepartingAndroid/app/src/main/assets/stations.json
+++ b/NowDepartingAndroid/app/src/main/assets/stations.json
@@ -2,3001 +2,5274 @@
   "1": [
     {
       "display": "Van Cortlandt Park-242nd Street",
-      "name": "Van Cortlandt Park-242 St"
+      "name": "Van Cortlandt Park-242 St",
+      "gtfsStopId": "101",
+      "latitude": 40.889248,
+      "longitude": -73.898583
     },
     {
       "display": "238th Street",
-      "name": "238 St"
+      "name": "238 St",
+      "gtfsStopId": "103",
+      "latitude": 40.884667,
+      "longitude": -73.90087
     },
     {
       "display": "231st Street",
-      "name": "231 St"
+      "name": "231 St",
+      "gtfsStopId": "104",
+      "latitude": 40.878856,
+      "longitude": -73.904834
     },
     {
       "display": "Marble Hill-225th Street",
-      "name": "Marble Hill-225 St"
+      "name": "Marble Hill-225 St",
+      "gtfsStopId": "106",
+      "latitude": 40.874561,
+      "longitude": -73.909831
     },
     {
       "display": "215th Street",
-      "name": "215 St"
+      "name": "215 St",
+      "gtfsStopId": "107",
+      "latitude": 40.869444,
+      "longitude": -73.915279
     },
     {
       "display": "207th Street",
-      "name": "207 St"
+      "name": "207 St",
+      "gtfsStopId": "108",
+      "latitude": 40.864621,
+      "longitude": -73.918822
     },
     {
       "display": "Dyckman Street",
-      "name": "Dyckman St"
+      "name": "Dyckman St",
+      "gtfsStopId": "109",
+      "latitude": 40.860531,
+      "longitude": -73.925536
     },
     {
       "display": "191st Street",
-      "name": "191 St"
+      "name": "191 St",
+      "gtfsStopId": "110",
+      "latitude": 40.855225,
+      "longitude": -73.929412
     },
     {
       "display": "181st Street",
-      "name": "181 St"
+      "name": "181 St",
+      "gtfsStopId": "111",
+      "latitude": 40.849505,
+      "longitude": -73.933596
     },
     {
       "display": "168th Street",
-      "name": "168 St-Washington Hts"
+      "name": "168 St-Washington Hts",
+      "gtfsStopId": "112",
+      "latitude": 40.840556,
+      "longitude": -73.940133
     },
     {
       "display": "157th Street",
-      "name": "157 St"
+      "name": "157 St",
+      "gtfsStopId": "113",
+      "latitude": 40.834041,
+      "longitude": -73.94489
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "114",
+      "latitude": 40.826551,
+      "longitude": -73.95036
     },
     {
       "display": "137th Street-City College",
-      "name": "137 St-City College"
+      "name": "137 St-City College",
+      "gtfsStopId": "115",
+      "latitude": 40.822008,
+      "longitude": -73.953676
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "116",
+      "latitude": 40.815581,
+      "longitude": -73.958372
     },
     {
       "display": "116th Street-Columbia University",
-      "name": "116 St-Columbia University"
+      "name": "116 St-Columbia University",
+      "gtfsStopId": "117",
+      "latitude": 40.807722,
+      "longitude": -73.96411
     },
     {
       "display": "Cathedral Parkway-110th Street",
-      "name": "Cathedral Pkwy (110 St)"
+      "name": "Cathedral Pkwy (110 St)",
+      "gtfsStopId": "118",
+      "latitude": 40.803967,
+      "longitude": -73.966847
     },
     {
       "display": "103rd Street",
-      "name": "103 St"
+      "name": "103 St",
+      "gtfsStopId": "119",
+      "latitude": 40.799446,
+      "longitude": -73.968379
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "120",
+      "latitude": 40.793919,
+      "longitude": -73.972323
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "121",
+      "latitude": 40.788644,
+      "longitude": -73.976218
     },
     {
       "display": "79th Street",
-      "name": "79 St"
+      "name": "79 St",
+      "gtfsStopId": "122",
+      "latitude": 40.783934,
+      "longitude": -73.979917
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "123",
+      "latitude": 40.778453,
+      "longitude": -73.98197
     },
     {
       "display": "66th Street-Lincoln Center",
-      "name": "66 St-Lincoln Center"
+      "name": "66 St-Lincoln Center",
+      "gtfsStopId": "124",
+      "latitude": 40.77344,
+      "longitude": -73.982209
     },
     {
       "display": "59th Street-Columbus Circle",
-      "name": "59 St-Columbus Circle"
+      "name": "59 St-Columbus Circle",
+      "gtfsStopId": "125",
+      "latitude": 40.768247,
+      "longitude": -73.981929
     },
     {
       "display": "50th Street",
-      "name": "50 St"
+      "name": "50 St",
+      "gtfsStopId": "126",
+      "latitude": 40.761728,
+      "longitude": -73.983849
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "127",
+      "latitude": 40.75529,
+      "longitude": -73.987495
     },
     {
       "display": "34th Street-Penn Station",
-      "name": "34 St-Penn Station"
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "128",
+      "latitude": 40.750373,
+      "longitude": -73.991057
     },
     {
       "display": "28th Street",
-      "name": "28 St"
+      "name": "28 St",
+      "gtfsStopId": "129",
+      "latitude": 40.747215,
+      "longitude": -73.993365
     },
     {
       "display": "23rd Street",
-      "name": "23 St"
+      "name": "23 St",
+      "gtfsStopId": "130",
+      "latitude": 40.744081,
+      "longitude": -73.995657
     },
     {
       "display": "18th Street",
-      "name": "18 St"
+      "name": "18 St",
+      "gtfsStopId": "131",
+      "latitude": 40.74104,
+      "longitude": -73.997871
     },
     {
       "display": "14th Street",
-      "name": "14 St"
+      "name": "14 St",
+      "gtfsStopId": "132",
+      "latitude": 40.737826,
+      "longitude": -74.000201
     },
     {
-      "display": "Christopher Street-Sheridan Square",
-      "name": "Christopher St-Sheridan Sq"
+      "display": "Christopher St-Stonewall",
+      "name": "Christopher St-Stonewall",
+      "gtfsStopId": "133",
+      "latitude": 40.733422,
+      "longitude": -74.002906
     },
     {
       "display": "Houston Street",
-      "name": "Houston St"
+      "name": "Houston St",
+      "gtfsStopId": "134",
+      "latitude": 40.728251,
+      "longitude": -74.005367
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "135",
+      "latitude": 40.722854,
+      "longitude": -74.006277
     },
     {
       "display": "Franklin Street",
-      "name": "Franklin St"
+      "name": "Franklin St",
+      "gtfsStopId": "136",
+      "latitude": 40.719318,
+      "longitude": -74.006886
     },
     {
       "display": "Chambers Street",
-      "name": "Chambers St"
+      "name": "Chambers St",
+      "gtfsStopId": "137",
+      "latitude": 40.715478,
+      "longitude": -74.009266
     },
     {
       "display": "Cortlandt Street",
-      "name": "WTC Cortlandt"
+      "name": "WTC Cortlandt",
+      "gtfsStopId": "138",
+      "latitude": 40.711835,
+      "longitude": -74.012188
     },
     {
       "display": "Rector Street",
-      "name": "Rector St"
+      "name": "Rector St",
+      "gtfsStopId": "139",
+      "latitude": 40.707513,
+      "longitude": -74.013783
     },
     {
       "display": "South Ferry",
-      "name": "South Ferry"
+      "name": "South Ferry",
+      "gtfsStopId": "142",
+      "latitude": 40.702068,
+      "longitude": -74.013664
     }
   ],
   "2": [
     {
       "display": "Wakefield-241st Street",
-      "name": "Wakefield-241 St"
+      "name": "Wakefield-241 St",
+      "gtfsStopId": "201",
+      "latitude": 40.903125,
+      "longitude": -73.85062
     },
     {
       "display": "Nereid Avenue",
-      "name": "Nereid Av"
+      "name": "Nereid Av",
+      "gtfsStopId": "204",
+      "latitude": 40.898379,
+      "longitude": -73.854376
     },
     {
       "display": "233rd Street",
-      "name": "233 St"
+      "name": "233 St",
+      "gtfsStopId": "205",
+      "latitude": 40.893193,
+      "longitude": -73.857473
     },
     {
       "display": "225th Street",
-      "name": "225 St"
+      "name": "225 St",
+      "gtfsStopId": "206",
+      "latitude": 40.888022,
+      "longitude": -73.860341
     },
     {
       "display": "219th Street",
-      "name": "219 St"
+      "name": "219 St",
+      "gtfsStopId": "207",
+      "latitude": 40.883895,
+      "longitude": -73.862633
     },
     {
       "display": "Gun Hill Road",
-      "name": "Gun Hill Rd"
+      "name": "Gun Hill Rd",
+      "gtfsStopId": "208",
+      "latitude": 40.87785,
+      "longitude": -73.866256
     },
     {
       "display": "Burke Avenue",
-      "name": "Burke Av"
+      "name": "Burke Av",
+      "gtfsStopId": "209",
+      "latitude": 40.871356,
+      "longitude": -73.867164
     },
     {
       "display": "Allerton Avenue",
-      "name": "Allerton Av"
+      "name": "Allerton Av",
+      "gtfsStopId": "210",
+      "latitude": 40.865462,
+      "longitude": -73.867352
     },
     {
       "display": "Pelham Parkway",
-      "name": "Pelham Pkwy"
+      "name": "Pelham Pkwy",
+      "gtfsStopId": "211",
+      "latitude": 40.857192,
+      "longitude": -73.867615
     },
     {
       "display": "Bronx Park East",
-      "name": "Bronx Park East"
+      "name": "Bronx Park East",
+      "gtfsStopId": "212",
+      "latitude": 40.848828,
+      "longitude": -73.868457
     },
     {
       "display": "East 180th Street",
-      "name": "E 180 St"
+      "name": "E 180 St",
+      "gtfsStopId": "213",
+      "latitude": 40.841894,
+      "longitude": -73.873488
     },
     {
       "display": "West Farms Square-East Tremont Avenue",
-      "name": "West Farms Sq-E Tremont Av"
+      "name": "West Farms Sq-E Tremont Av",
+      "gtfsStopId": "214",
+      "latitude": 40.840295,
+      "longitude": -73.880049
     },
     {
       "display": "174th Street",
-      "name": "174 St"
+      "name": "174 St",
+      "gtfsStopId": "215",
+      "latitude": 40.837288,
+      "longitude": -73.887734
     },
     {
       "display": "Freeman Street",
-      "name": "Freeman St"
+      "name": "Freeman St",
+      "gtfsStopId": "216",
+      "latitude": 40.829993,
+      "longitude": -73.891865
     },
     {
       "display": "Simpson Street",
-      "name": "Simpson St"
+      "name": "Simpson St",
+      "gtfsStopId": "217",
+      "latitude": 40.824073,
+      "longitude": -73.893064
     },
     {
       "display": "Intervale Avenue",
-      "name": "Intervale Av"
+      "name": "Intervale Av",
+      "gtfsStopId": "218",
+      "latitude": 40.822181,
+      "longitude": -73.896736
     },
     {
       "display": "Prospect Avenue",
-      "name": "Prospect Av"
+      "name": "Prospect Av",
+      "gtfsStopId": "219",
+      "latitude": 40.819585,
+      "longitude": -73.90177
     },
     {
       "display": "Jackson Avenue",
-      "name": "Jackson Av"
+      "name": "Jackson Av",
+      "gtfsStopId": "220",
+      "latitude": 40.81649,
+      "longitude": -73.907807
     },
     {
       "display": "3rd Avenue-149th Street",
-      "name": "3 Av-149 St"
+      "name": "3 Av-149 St",
+      "gtfsStopId": "221",
+      "latitude": 40.816109,
+      "longitude": -73.917757
     },
     {
       "display": "149th Street-Grand Concourse",
-      "name": "149 St-Grand Concourse"
+      "name": "149 St-Grand Concourse",
+      "gtfsStopId": "222",
+      "latitude": 40.81841,
+      "longitude": -73.926718
     },
     {
       "display": "135th Street",
-      "name": "135 St"
+      "name": "135 St",
+      "gtfsStopId": "224",
+      "latitude": 40.814229,
+      "longitude": -73.94077
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "225",
+      "latitude": 40.807754,
+      "longitude": -73.945495
     },
     {
       "display": "116th Street",
-      "name": "116 St"
+      "name": "116 St",
+      "gtfsStopId": "226",
+      "latitude": 40.802098,
+      "longitude": -73.949625
     },
     {
-      "display": "Central Park North-110th Street",
-      "name": "Central Park North (110 St)"
+      "display": "110 St-Malcom X Plaza",
+      "name": "110 St-Malcolm X Plaza",
+      "gtfsStopId": "227",
+      "latitude": 40.799075,
+      "longitude": -73.951822
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "120",
+      "latitude": 40.793919,
+      "longitude": -73.972323
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "123",
+      "latitude": 40.778453,
+      "longitude": -73.98197
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "127",
+      "latitude": 40.75529,
+      "longitude": -73.987495
     },
     {
       "display": "34th Street-Penn Station",
-      "name": "34 St-Penn Station"
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "128",
+      "latitude": 40.750373,
+      "longitude": -73.991057
     },
     {
       "display": "14th Street",
-      "name": "14 St"
+      "name": "14 St",
+      "gtfsStopId": "132",
+      "latitude": 40.737826,
+      "longitude": -74.000201
     },
     {
       "display": "Chambers Street",
-      "name": "Chambers St"
+      "name": "Chambers St",
+      "gtfsStopId": "228",
+      "latitude": 40.713051,
+      "longitude": -74.008811
     },
     {
       "display": "Park Place",
-      "name": "Park Place"
+      "name": "Park Place",
+      "gtfsStopId": "228",
+      "latitude": 40.713051,
+      "longitude": -74.008811
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "229",
+      "latitude": 40.709416,
+      "longitude": -74.006571
     },
     {
       "display": "Wall Street",
-      "name": "Wall St"
+      "name": "Wall St",
+      "gtfsStopId": "230",
+      "latitude": 40.706821,
+      "longitude": -74.0091
     },
     {
       "display": "Clark Street",
-      "name": "Clark St"
+      "name": "Clark St",
+      "gtfsStopId": "231",
+      "latitude": 40.697466,
+      "longitude": -73.993086
     },
     {
-      "display": "Borough Hall",
-      "name": "Court St / Borough Hall"
+      "display": "Court St-Borough Hall",
+      "name": "Court St",
+      "gtfsStopId": "232",
+      "latitude": 40.693219,
+      "longitude": -73.989998
     },
     {
       "display": "Hoyt Street",
-      "name": "Hoyt St"
+      "name": "Hoyt St",
+      "gtfsStopId": "233",
+      "latitude": 40.690545,
+      "longitude": -73.985065
     },
     {
       "display": "Nevins Street",
-      "name": "Nevins St"
+      "name": "Nevins St",
+      "gtfsStopId": "234",
+      "latitude": 40.688246,
+      "longitude": -73.980492
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "235",
+      "latitude": 40.684359,
+      "longitude": -73.977666
     },
     {
       "display": "Bergen Street",
-      "name": "Bergen St"
+      "name": "Bergen St",
+      "gtfsStopId": "236",
+      "latitude": 40.680829,
+      "longitude": -73.975098
     },
     {
       "display": "Grand Army Plaza",
-      "name": "Grand Army Plaza"
+      "name": "Grand Army Plaza",
+      "gtfsStopId": "237",
+      "latitude": 40.675235,
+      "longitude": -73.971046
     },
     {
       "display": "Eastern Parkway-Brooklyn Museum",
-      "name": "Eastern Pkwy-Brooklyn Museum"
+      "name": "Eastern Pkwy-Brooklyn Museum",
+      "gtfsStopId": "238",
+      "latitude": 40.671987,
+      "longitude": -73.964375
     },
     {
       "display": "Franklin Avenue-Medgar Evers College",
-      "name": "Franklin Av / Botanic Garden"
+      "name": "Franklin Av-Medgar Evers College",
+      "gtfsStopId": "239",
+      "latitude": 40.670682,
+      "longitude": -73.958131
     },
     {
       "display": "President Street-Medgar Evers College",
-      "name": "President St-Medgar Evers College"
+      "name": "President St-Medgar Evers College",
+      "gtfsStopId": "241",
+      "latitude": 40.667883,
+      "longitude": -73.950683
     },
     {
       "display": "Sterling Street",
-      "name": "Sterling St"
+      "name": "Sterling St",
+      "gtfsStopId": "242",
+      "latitude": 40.662742,
+      "longitude": -73.95085
     },
     {
       "display": "Winthrop Street",
-      "name": "Winthrop St"
+      "name": "Winthrop St",
+      "gtfsStopId": "243",
+      "latitude": 40.656652,
+      "longitude": -73.9502
     },
     {
       "display": "Church Avenue",
-      "name": "Church Av"
+      "name": "Church Av",
+      "gtfsStopId": "244",
+      "latitude": 40.650843,
+      "longitude": -73.949575
     },
     {
       "display": "Beverly Road",
-      "name": "Beverly Rd"
+      "name": "Beverly Rd",
+      "gtfsStopId": "245",
+      "latitude": 40.645098,
+      "longitude": -73.948959
     },
     {
       "display": "Newkirk Avenue-Little Haiti",
-      "name": "Newkirk Av-Little Haiti"
+      "name": "Newkirk Av-Little Haiti",
+      "gtfsStopId": "246",
+      "latitude": 40.639967,
+      "longitude": -73.948411
     },
     {
       "display": "Flatbush Avenue-Brooklyn College",
-      "name": "Flatbush Av-Brooklyn College"
+      "name": "Flatbush Av-Brooklyn College",
+      "gtfsStopId": "247",
+      "latitude": 40.632836,
+      "longitude": -73.947642
     }
   ],
   "3": [
     {
       "display": "Harlem-148th Street",
-      "name": "Harlem-148 St"
+      "name": "Harlem-148 St",
+      "gtfsStopId": "301",
+      "latitude": 40.82388,
+      "longitude": -73.93647
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "302",
+      "latitude": 40.820421,
+      "longitude": -73.936245
     },
     {
       "display": "135th Street",
-      "name": "135 St"
+      "name": "135 St",
+      "gtfsStopId": "224",
+      "latitude": 40.814229,
+      "longitude": -73.94077
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "225",
+      "latitude": 40.807754,
+      "longitude": -73.945495
     },
     {
       "display": "116th Street",
-      "name": "116 St"
+      "name": "116 St",
+      "gtfsStopId": "226",
+      "latitude": 40.802098,
+      "longitude": -73.949625
     },
     {
-      "display": "Central Park North-110th Street",
-      "name": "Central Park North (110 St)"
+      "display": "110 St-Malcom X Plaza",
+      "name": "110 St-Malcolm X Plaza",
+      "gtfsStopId": "227",
+      "latitude": 40.799075,
+      "longitude": -73.951822
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "120",
+      "latitude": 40.793919,
+      "longitude": -73.972323
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "123",
+      "latitude": 40.778453,
+      "longitude": -73.98197
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "127",
+      "latitude": 40.75529,
+      "longitude": -73.987495
     },
     {
       "display": "34th Street-Penn Station",
-      "name": "34 St-Penn Station"
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "128",
+      "latitude": 40.750373,
+      "longitude": -73.991057
     },
     {
       "display": "14th Street",
-      "name": "14 St"
+      "name": "14 St",
+      "gtfsStopId": "132",
+      "latitude": 40.737826,
+      "longitude": -74.000201
     },
     {
       "display": "Chambers Street",
-      "name": "Chambers St"
+      "name": "Chambers St",
+      "gtfsStopId": "228",
+      "latitude": 40.713051,
+      "longitude": -74.008811
     },
     {
       "display": "Park Place",
-      "name": "Park Pl"
+      "name": "Park Pl",
+      "gtfsStopId": "228",
+      "latitude": 40.713051,
+      "longitude": -74.008811
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "229",
+      "latitude": 40.709416,
+      "longitude": -74.006571
     },
     {
       "display": "Wall Street",
-      "name": "Wall St"
+      "name": "Wall St",
+      "gtfsStopId": "230",
+      "latitude": 40.706821,
+      "longitude": -74.0091
     },
     {
       "display": "Clark Street",
-      "name": "Clark St"
+      "name": "Clark St",
+      "gtfsStopId": "231",
+      "latitude": 40.697466,
+      "longitude": -73.993086
     },
     {
-      "display": "Borough Hall",
-      "name": "Court St / Borough Hall"
+      "display": "Court St-Borough Hall",
+      "name": "Court St",
+      "gtfsStopId": "232",
+      "latitude": 40.693219,
+      "longitude": -73.989998
     },
     {
       "display": "Hoyt Street",
-      "name": "Hoyt St"
+      "name": "Hoyt St",
+      "gtfsStopId": "233",
+      "latitude": 40.690545,
+      "longitude": -73.985065
     },
     {
       "display": "Nevins Street",
-      "name": "Nevins St"
+      "name": "Nevins St",
+      "gtfsStopId": "234",
+      "latitude": 40.688246,
+      "longitude": -73.980492
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "235",
+      "latitude": 40.684359,
+      "longitude": -73.977666
     },
     {
       "display": "Bergen Street",
-      "name": "Bergen St"
+      "name": "Bergen St",
+      "gtfsStopId": "236",
+      "latitude": 40.680829,
+      "longitude": -73.975098
     },
     {
       "display": "Grand Army Plaza",
-      "name": "Grand Army Plaza"
+      "name": "Grand Army Plaza",
+      "gtfsStopId": "237",
+      "latitude": 40.675235,
+      "longitude": -73.971046
     },
     {
       "display": "Eastern Parkway-Brooklyn Museum",
-      "name": "Eastern Pkwy-Brooklyn Museum"
+      "name": "Eastern Pkwy-Brooklyn Museum",
+      "gtfsStopId": "238",
+      "latitude": 40.671987,
+      "longitude": -73.964375
     },
     {
       "display": "Franklin Avenue-Medgar Evers College",
-      "name": "Franklin Av / Botanic Garden"
+      "name": "Franklin Av-Medgar Evers College",
+      "gtfsStopId": "239",
+      "latitude": 40.670682,
+      "longitude": -73.958131
     },
     {
       "display": "Nostrand Avenue",
-      "name": "Nostrand Av"
+      "name": "Nostrand Av",
+      "gtfsStopId": "248",
+      "latitude": 40.669847,
+      "longitude": -73.950466
     },
     {
       "display": "Kingston Avenue",
-      "name": "Kingston Av"
+      "name": "Kingston Av",
+      "gtfsStopId": "249",
+      "latitude": 40.669399,
+      "longitude": -73.942161
     },
     {
       "display": "Crown Heights-Utica Avenue",
-      "name": "Crown Hts-Utica Av"
+      "name": "Crown Hts-Utica Av",
+      "gtfsStopId": "250",
+      "latitude": 40.668897,
+      "longitude": -73.932942
     },
     {
       "display": "Sutter Avenue-Rutland Road",
-      "name": "Sutter Av-Rutland Rd"
+      "name": "Sutter Av-Rutland Rd",
+      "gtfsStopId": "251",
+      "latitude": 40.664717,
+      "longitude": -73.92261
     },
     {
       "display": "Saratoga Avenue",
-      "name": "Saratoga Av"
+      "name": "Saratoga Av",
+      "gtfsStopId": "252",
+      "latitude": 40.661453,
+      "longitude": -73.916327
     },
     {
       "display": "Rockaway Avenue",
-      "name": "Rockaway Av"
+      "name": "Rockaway Av",
+      "gtfsStopId": "253",
+      "latitude": 40.662549,
+      "longitude": -73.908946
     },
     {
-      "display": "Junius Street",
-      "name": "Junius St / Livonia Av"
+      "display": "Livonia Avenue",
+      "name": "Livonia Av",
+      "gtfsStopId": "254",
+      "latitude": 40.663515,
+      "longitude": -73.902447
     },
     {
       "display": "Pennsylvania Avenue",
-      "name": "Pennsylvania Av"
+      "name": "Pennsylvania Av",
+      "gtfsStopId": "255",
+      "latitude": 40.664635,
+      "longitude": -73.894895
     },
     {
       "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
+      "name": "Van Siclen Av",
+      "gtfsStopId": "256",
+      "latitude": 40.665449,
+      "longitude": -73.889395
     },
     {
       "display": "New Lots Avenue",
-      "name": "New Lots Av"
+      "name": "New Lots Av",
+      "gtfsStopId": "257",
+      "latitude": 40.666235,
+      "longitude": -73.884079
     }
   ],
   "4": [
     {
       "display": "Woodlawn",
-      "name": "Woodlawn"
+      "name": "Woodlawn",
+      "gtfsStopId": "401",
+      "latitude": 40.886037,
+      "longitude": -73.878751
     },
     {
       "display": "Mosholu Parkway",
-      "name": "Mosholu Pkwy"
+      "name": "Mosholu Pkwy",
+      "gtfsStopId": "402",
+      "latitude": 40.87975,
+      "longitude": -73.884655
     },
     {
       "display": "Bedford Park Boulevard-Lehman College",
-      "name": "Bedford Park Blvd-Lehman College"
+      "name": "Bedford Park Blvd-Lehman College",
+      "gtfsStopId": "405",
+      "latitude": 40.873412,
+      "longitude": -73.890064
     },
     {
       "display": "Kingsbridge Road",
-      "name": "Kingsbridge Rd"
+      "name": "Kingsbridge Rd",
+      "gtfsStopId": "406",
+      "latitude": 40.86776,
+      "longitude": -73.897174
     },
     {
       "display": "Fordham Road",
-      "name": "Fordham Rd"
+      "name": "Fordham Rd",
+      "gtfsStopId": "407",
+      "latitude": 40.862803,
+      "longitude": -73.901034
     },
     {
       "display": "183rd Street",
-      "name": "183 St"
+      "name": "183 St",
+      "gtfsStopId": "408",
+      "latitude": 40.858407,
+      "longitude": -73.903879
     },
     {
       "display": "Burnside Avenue",
-      "name": "Burnside Av"
+      "name": "Burnside Av",
+      "gtfsStopId": "409",
+      "latitude": 40.853453,
+      "longitude": -73.907684
     },
     {
       "display": "176th Street",
-      "name": "176 St"
+      "name": "176 St",
+      "gtfsStopId": "410",
+      "latitude": 40.84848,
+      "longitude": -73.911794
     },
     {
       "display": "Mt. Eden Avenue",
-      "name": "Mt Eden Av"
+      "name": "Mt Eden Av",
+      "gtfsStopId": "411",
+      "latitude": 40.844434,
+      "longitude": -73.914685
     },
     {
       "display": "170th Street",
-      "name": "170 St"
+      "name": "170 St",
+      "gtfsStopId": "412",
+      "latitude": 40.840075,
+      "longitude": -73.917791
     },
     {
       "display": "167th Street",
-      "name": "167 St"
+      "name": "167 St",
+      "gtfsStopId": "413",
+      "latitude": 40.835537,
+      "longitude": -73.9214
     },
     {
       "display": "161st Street-Yankee Stadium",
-      "name": "161 St-Yankee Stadium"
+      "name": "161 St-Yankee Stadium",
+      "gtfsStopId": "414",
+      "latitude": 40.827994,
+      "longitude": -73.925831
     },
     {
       "display": "149th Street-Grand Concourse",
-      "name": "149 St-Grand Concourse"
+      "name": "149 St-Grand Concourse",
+      "gtfsStopId": "415",
+      "latitude": 40.818375,
+      "longitude": -73.927351
     },
     {
       "display": "138th Street-Grand Concourse",
-      "name": "138 St-Grand Concourse"
+      "name": "138 St-Grand Concourse",
+      "gtfsStopId": "416",
+      "latitude": 40.813224,
+      "longitude": -73.929849
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "621",
+      "latitude": 40.804138,
+      "longitude": -73.937594
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "626",
+      "latitude": 40.779492,
+      "longitude": -73.955589
     },
     {
       "display": "59th Street",
-      "name": "Lexington Av/59 St"
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "629",
+      "latitude": 40.762526,
+      "longitude": -73.967967
     },
     {
       "display": "42nd Street-Grand Central",
-      "name": "Grand Central-42 St"
+      "name": "Grand Central-42 St",
+      "gtfsStopId": "631",
+      "latitude": 40.751776,
+      "longitude": -73.976848
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "635",
+      "latitude": 40.734673,
+      "longitude": -73.989951
     },
     {
       "display": "Brooklyn Bridge-City Hall",
-      "name": "Brooklyn Bridge-City Hall / Chambers St"
+      "name": "Brooklyn Bridge-City Hall / Chambers St",
+      "gtfsStopId": "640",
+      "latitude": 40.713065,
+      "longitude": -74.004131
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "418",
+      "latitude": 40.710368,
+      "longitude": -74.009509
     },
     {
       "display": "Wall Street",
-      "name": "Wall St"
+      "name": "Wall St",
+      "gtfsStopId": "419",
+      "latitude": 40.707557,
+      "longitude": -74.011862
     },
     {
       "display": "Bowling Green",
-      "name": "Bowling Green"
+      "name": "Bowling Green",
+      "gtfsStopId": "420",
+      "latitude": 40.704817,
+      "longitude": -74.014065
     },
     {
-      "display": "Borough Hall",
-      "name": "Court St / Borough Hall"
+      "display": "Court St-Borough Hall",
+      "name": "Court St",
+      "gtfsStopId": "423",
+      "latitude": 40.692404,
+      "longitude": -73.990151
     },
     {
       "display": "Nevins Street",
-      "name": "Nevins St"
+      "name": "Nevins St",
+      "gtfsStopId": "234",
+      "latitude": 40.688246,
+      "longitude": -73.980492
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "235",
+      "latitude": 40.684359,
+      "longitude": -73.977666
     },
     {
       "display": "Franklin Avenue-Medgar Evers College",
-      "name": "Franklin Av / Botanic Garden"
+      "name": "Franklin Av-Medgar Evers College",
+      "gtfsStopId": "239",
+      "latitude": 40.670682,
+      "longitude": -73.958131
     },
     {
       "display": "Crown Heights-Utica Avenue",
-      "name": "Crown Hts-Utica Av"
-    },
-    {
-      "display": "Sutter Avenue-Rutland Road",
-      "name": "Sutter Av-Rutland Rd"
-    },
-    {
-      "display": "Saratoga Avenue",
-      "name": "Saratoga Av"
-    },
-    {
-      "display": "Rockaway Avenue",
-      "name": "Rockaway Av"
-    },
-    {
-      "display": "Junius Street",
-      "name": "Junius St / Livonia Av"
-    },
-    {
-      "display": "Pennsylvania Avenue",
-      "name": "Pennsylvania Av"
-    },
-    {
-      "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
-    },
-    {
-      "display": "New Lots Avenue",
-      "name": "New Lots Av"
+      "name": "Crown Hts-Utica Av",
+      "gtfsStopId": "250",
+      "latitude": 40.668897,
+      "longitude": -73.932942
     }
   ],
   "5": [
     {
       "display": "Eastchester-Dyre Avenue",
-      "name": "Eastchester-Dyre Av"
+      "name": "Eastchester-Dyre Av",
+      "gtfsStopId": "501",
+      "latitude": 40.8883,
+      "longitude": -73.830834
     },
     {
       "display": "Baychester Avenue",
-      "name": "Baychester Av"
+      "name": "Baychester Av",
+      "gtfsStopId": "502",
+      "latitude": 40.878663,
+      "longitude": -73.838591
     },
     {
       "display": "Gun Hill Road",
-      "name": "Gun Hill Rd"
+      "name": "Gun Hill Rd",
+      "gtfsStopId": "503",
+      "latitude": 40.869526,
+      "longitude": -73.846384
     },
     {
       "display": "Pelham Parkway",
-      "name": "Pelham Pkwy"
+      "name": "Pelham Pkwy",
+      "gtfsStopId": "504",
+      "latitude": 40.858985,
+      "longitude": -73.855359
     },
     {
       "display": "Morris Park",
-      "name": "Morris Park"
+      "name": "Morris Park",
+      "gtfsStopId": "505",
+      "latitude": 40.854364,
+      "longitude": -73.860495
     },
     {
       "display": "East 180th Street",
-      "name": "E 180 St"
+      "name": "E 180 St",
+      "gtfsStopId": "213",
+      "latitude": 40.841894,
+      "longitude": -73.873488
     },
     {
       "display": "West Farms Square-East Tremont Avenue",
-      "name": "West Farms Sq-E Tremont Av"
+      "name": "West Farms Sq-E Tremont Av",
+      "gtfsStopId": "214",
+      "latitude": 40.840295,
+      "longitude": -73.880049
     },
     {
       "display": "174th Street",
-      "name": "174 St"
+      "name": "174 St",
+      "gtfsStopId": "215",
+      "latitude": 40.837288,
+      "longitude": -73.887734
     },
     {
       "display": "Freeman Street",
-      "name": "Freeman St"
+      "name": "Freeman St",
+      "gtfsStopId": "216",
+      "latitude": 40.829993,
+      "longitude": -73.891865
     },
     {
       "display": "Simpson Street",
-      "name": "Simpson St"
+      "name": "Simpson St",
+      "gtfsStopId": "217",
+      "latitude": 40.824073,
+      "longitude": -73.893064
     },
     {
       "display": "Intervale Avenue",
-      "name": "Intervale Av"
+      "name": "Intervale Av",
+      "gtfsStopId": "218",
+      "latitude": 40.822181,
+      "longitude": -73.896736
     },
     {
       "display": "Prospect Avenue",
-      "name": "Prospect Av"
+      "name": "Prospect Av",
+      "gtfsStopId": "219",
+      "latitude": 40.819585,
+      "longitude": -73.90177
     },
     {
       "display": "Jackson Avenue",
-      "name": "Jackson Av"
+      "name": "Jackson Av",
+      "gtfsStopId": "220",
+      "latitude": 40.81649,
+      "longitude": -73.907807
     },
     {
       "display": "3rd Avenue-149th Street",
-      "name": "3 Av-149 St"
+      "name": "3 Av-149 St",
+      "gtfsStopId": "221",
+      "latitude": 40.816109,
+      "longitude": -73.917757
     },
     {
       "display": "149th Street-Grand Concourse",
-      "name": "149 St-Grand Concourse"
+      "name": "149 St-Grand Concourse",
+      "gtfsStopId": "222",
+      "latitude": 40.81841,
+      "longitude": -73.926718
     },
     {
       "display": "138th Street-Grand Concourse",
-      "name": "138 St-Grand Concourse"
+      "name": "138 St-Grand Concourse",
+      "gtfsStopId": "416",
+      "latitude": 40.813224,
+      "longitude": -73.929849
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "621",
+      "latitude": 40.804138,
+      "longitude": -73.937594
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "626",
+      "latitude": 40.779492,
+      "longitude": -73.955589
     },
     {
       "display": "59th Street",
-      "name": "Lexington Av/59 St"
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "629",
+      "latitude": 40.762526,
+      "longitude": -73.967967
     },
     {
       "display": "42nd Street-Grand Central",
-      "name": "42 St-Grand Central"
+      "name": "42 St-Grand Central",
+      "gtfsStopId": "631",
+      "latitude": 40.751776,
+      "longitude": -73.976848
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "635",
+      "latitude": 40.734673,
+      "longitude": -73.989951
     },
     {
       "display": "Brooklyn Bridge-City Hall",
-      "name": "Brooklyn Bridge-City Hall / Chambers St"
+      "name": "Brooklyn Bridge-City Hall / Chambers St",
+      "gtfsStopId": "640",
+      "latitude": 40.713065,
+      "longitude": -74.004131
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "418",
+      "latitude": 40.710368,
+      "longitude": -74.009509
     },
     {
       "display": "Wall Street",
-      "name": "Wall St"
+      "name": "Wall St",
+      "gtfsStopId": "419",
+      "latitude": 40.707557,
+      "longitude": -74.011862
     },
     {
       "display": "Bowling Green",
-      "name": "Bowling Green"
+      "name": "Bowling Green",
+      "gtfsStopId": "420",
+      "latitude": 40.704817,
+      "longitude": -74.014065
     },
     {
-      "display": "Borough Hall",
-      "name": "Court St / Borough Hall"
+      "display": "Court St-Borough Hall",
+      "name": "Court St",
+      "gtfsStopId": "423",
+      "latitude": 40.692404,
+      "longitude": -73.990151
     },
     {
       "display": "Nevins Street",
-      "name": "Nevins St"
+      "name": "Nevins St",
+      "gtfsStopId": "234",
+      "latitude": 40.688246,
+      "longitude": -73.980492
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "235",
+      "latitude": 40.684359,
+      "longitude": -73.977666
     },
     {
       "display": "Franklin Avenue-Medgar Evers College",
-      "name": "Franklin Av / Botanic Garden"
+      "name": "Franklin Av-Medgar Evers College",
+      "gtfsStopId": "239",
+      "latitude": 40.670682,
+      "longitude": -73.958131
     },
     {
       "display": "Crown Heights-Utica Avenue",
-      "name": "Crown Hts-Utica Av"
+      "name": "Crown Hts-Utica Av",
+      "gtfsStopId": "250",
+      "latitude": 40.668897,
+      "longitude": -73.932942
+    },
+    {
+      "display": "President Street-Medgar Evers College",
+      "name": "President St-Medgar Evers College",
+      "gtfsStopId": "241",
+      "latitude": 40.667883,
+      "longitude": -73.950683
+    },
+    {
+      "display": "Sterling Street",
+      "name": "Sterling St",
+      "gtfsStopId": "242",
+      "latitude": 40.662742,
+      "longitude": -73.95085
+    },
+    {
+      "display": "Winthrop Street",
+      "name": "Winthrop St",
+      "gtfsStopId": "243",
+      "latitude": 40.656652,
+      "longitude": -73.9502
+    },
+    {
+      "display": "Church Avenue",
+      "name": "Church Av",
+      "gtfsStopId": "244",
+      "latitude": 40.650843,
+      "longitude": -73.949575
+    },
+    {
+      "display": "Beverly Road",
+      "name": "Beverly Rd",
+      "gtfsStopId": "245",
+      "latitude": 40.645098,
+      "longitude": -73.948959
+    },
+    {
+      "display": "Newkirk Avenue-Little Haiti",
+      "name": "Newkirk Av-Little Haiti",
+      "gtfsStopId": "246",
+      "latitude": 40.639967,
+      "longitude": -73.948411
+    },
+    {
+      "display": "Flatbush Avenue-Brooklyn College",
+      "name": "Flatbush Av-Brooklyn College",
+      "gtfsStopId": "247",
+      "latitude": 40.632836,
+      "longitude": -73.947642
     }
   ],
   "6": [
     {
       "display": "Pelham Bay Park",
-      "name": "Pelham Bay Park"
+      "name": "Pelham Bay Park",
+      "gtfsStopId": "601",
+      "latitude": 40.852462,
+      "longitude": -73.828121
     },
     {
       "display": "Buhre Avenue",
-      "name": "Buhre Av"
+      "name": "Buhre Av",
+      "gtfsStopId": "602",
+      "latitude": 40.84681,
+      "longitude": -73.832569
     },
     {
       "display": "Middletown Road",
-      "name": "Middletown Rd"
+      "name": "Middletown Rd",
+      "gtfsStopId": "603",
+      "latitude": 40.843863,
+      "longitude": -73.836322
     },
     {
       "display": "Westchester Square-East Tremont Avenue",
-      "name": "Westchester Sq-E Tremont Av"
+      "name": "Westchester Sq-E Tremont Av",
+      "gtfsStopId": "604",
+      "latitude": 40.839892,
+      "longitude": -73.842952
     },
     {
       "display": "Zerega Avenue",
-      "name": "Zerega Av"
+      "name": "Zerega Av",
+      "gtfsStopId": "606",
+      "latitude": 40.836488,
+      "longitude": -73.847036
     },
     {
       "display": "Castle Hill Avenue",
-      "name": "Castle Hill Av"
+      "name": "Castle Hill Av",
+      "gtfsStopId": "607",
+      "latitude": 40.834255,
+      "longitude": -73.851222
     },
     {
       "display": "Parkchester",
-      "name": "Parkchester"
+      "name": "Parkchester",
+      "gtfsStopId": "608",
+      "latitude": 40.833226,
+      "longitude": -73.860816
     },
     {
       "display": "St. Lawrence Avenue",
-      "name": "St Lawrence Av"
+      "name": "St Lawrence Av",
+      "gtfsStopId": "609",
+      "latitude": 40.831509,
+      "longitude": -73.867618
     },
     {
       "display": "Morrison Avenue-Soundview",
-      "name": "Morrison Av-Soundview"
+      "name": "Morrison Av-Soundview",
+      "gtfsStopId": "610",
+      "latitude": 40.829521,
+      "longitude": -73.874516
     },
     {
       "display": "Elder Avenue",
-      "name": "Elder Av"
+      "name": "Elder Av",
+      "gtfsStopId": "611",
+      "latitude": 40.828584,
+      "longitude": -73.879159
     },
     {
       "display": "Whitlock Avenue",
-      "name": "Whitlock Av"
+      "name": "Whitlock Av",
+      "gtfsStopId": "612",
+      "latitude": 40.826525,
+      "longitude": -73.886283
     },
     {
       "display": "Hunts Point Avenue",
-      "name": "Hunts Point Av"
+      "name": "Hunts Point Av",
+      "gtfsStopId": "613",
+      "latitude": 40.820948,
+      "longitude": -73.890549
     },
     {
       "display": "Longwood Avenue",
-      "name": "Longwood Av"
+      "name": "Longwood Av",
+      "gtfsStopId": "614",
+      "latitude": 40.816104,
+      "longitude": -73.896435
     },
     {
       "display": "E. 149th Street",
-      "name": "E 149 St"
+      "name": "E 149 St",
+      "gtfsStopId": "615",
+      "latitude": 40.812118,
+      "longitude": -73.904098
+    },
+    {
+      "display": "East 143rd Street-St Mary's Street",
+      "name": "E 143 St-St Mary's St",
+      "gtfsStopId": "616",
+      "latitude": 40.808719,
+      "longitude": -73.907657
+    },
+    {
+      "display": "Cypress Avenue",
+      "name": "Cypress Av",
+      "gtfsStopId": "617",
+      "latitude": 40.805368,
+      "longitude": -73.914042
     },
     {
       "display": "Brook Avenue",
-      "name": "Brook Av"
+      "name": "Brook Av",
+      "gtfsStopId": "618",
+      "latitude": 40.807566,
+      "longitude": -73.91924
     },
     {
       "display": "3rd Avenue-138th Street",
-      "name": "3 Av-138 St"
+      "name": "3 Av-138 St",
+      "gtfsStopId": "619",
+      "latitude": 40.810476,
+      "longitude": -73.926138
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "621",
+      "latitude": 40.804138,
+      "longitude": -73.937594
     },
     {
       "display": "116th Street",
-      "name": "116 St"
+      "name": "116 St",
+      "gtfsStopId": "622",
+      "latitude": 40.798629,
+      "longitude": -73.941617
     },
     {
       "display": "110th Street",
-      "name": "110 St"
+      "name": "110 St",
+      "gtfsStopId": "623",
+      "latitude": 40.79502,
+      "longitude": -73.94425
     },
     {
       "display": "103rd Street",
-      "name": "103 St"
+      "name": "103 St",
+      "gtfsStopId": "624",
+      "latitude": 40.7906,
+      "longitude": -73.947478
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "625",
+      "latitude": 40.785672,
+      "longitude": -73.95107
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "626",
+      "latitude": 40.779492,
+      "longitude": -73.955589
     },
     {
       "display": "77th Street",
-      "name": "77 St"
+      "name": "77 St",
+      "gtfsStopId": "627",
+      "latitude": 40.77362,
+      "longitude": -73.959874
     },
     {
       "display": "68th Street-Hunter College",
-      "name": "68 St-Hunter College"
+      "name": "68 St-Hunter College",
+      "gtfsStopId": "628",
+      "latitude": 40.768141,
+      "longitude": -73.96387
     },
     {
       "display": "59th Street",
-      "name": "Lexington Av/59 St"
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "629",
+      "latitude": 40.762526,
+      "longitude": -73.967967
     },
     {
       "display": "51st Street",
-      "name": "51 St / Lexington Av/53 St"
+      "name": "51 St / Lexington Av/53 St",
+      "gtfsStopId": "630",
+      "latitude": 40.757107,
+      "longitude": -73.97192
     },
     {
       "display": "Grand Central-42nd Street",
-      "name": "Grand Central-42 St"
+      "name": "Grand Central-42 St",
+      "gtfsStopId": "631",
+      "latitude": 40.751776,
+      "longitude": -73.976848
     },
     {
       "display": "33rd Street",
-      "name": "33 St"
+      "name": "33 St",
+      "gtfsStopId": "632",
+      "latitude": 40.746081,
+      "longitude": -73.982076
     },
     {
       "display": "28th Street",
-      "name": "28 St"
+      "name": "28 St",
+      "gtfsStopId": "633",
+      "latitude": 40.74307,
+      "longitude": -73.984264
     },
     {
       "display": "23rd Street",
-      "name": "23 St"
+      "name": "23 St",
+      "gtfsStopId": "634",
+      "latitude": 40.739864,
+      "longitude": -73.986599
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "635",
+      "latitude": 40.734673,
+      "longitude": -73.989951
     },
     {
       "display": "Astor Place",
-      "name": "Astor Pl"
+      "name": "Astor Pl",
+      "gtfsStopId": "636",
+      "latitude": 40.730054,
+      "longitude": -73.99107
     },
     {
       "display": "Bleecker Street",
-      "name": "Bleecker St / Broadway-Lafayette St"
+      "name": "Bleecker St / Broadway-Lafayette St",
+      "gtfsStopId": "637",
+      "latitude": 40.725915,
+      "longitude": -73.994659
     },
     {
       "display": "Spring Street",
-      "name": "Spring St"
+      "name": "Spring St",
+      "gtfsStopId": "638",
+      "latitude": 40.722301,
+      "longitude": -73.997141
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "639",
+      "latitude": 40.718803,
+      "longitude": -74.000193
     },
     {
       "display": "Brooklyn Bridge-City Hall",
-      "name": "Brooklyn Bridge-City Hall / Chambers St"
+      "name": "Brooklyn Bridge-City Hall / Chambers St",
+      "gtfsStopId": "640",
+      "latitude": 40.713065,
+      "longitude": -74.004131
     }
   ],
   "7": [
     {
       "display": "Flushing-Main Street",
-      "name": "Flushing-Main St"
+      "name": "Flushing-Main St",
+      "gtfsStopId": "701",
+      "latitude": 40.7596,
+      "longitude": -73.83003
     },
     {
       "display": "Mets-Willets Point",
-      "name": "Mets-Willets Point"
+      "name": "Mets-Willets Point",
+      "gtfsStopId": "702",
+      "latitude": 40.754622,
+      "longitude": -73.845625
     },
     {
       "display": "111th Street",
-      "name": "111 St"
+      "name": "111 St",
+      "gtfsStopId": "705",
+      "latitude": 40.75173,
+      "longitude": -73.855334
     },
     {
       "display": "103rd Street-Corona Plaza",
-      "name": "103 St-Corona Plaza"
+      "name": "103 St-Corona Plaza",
+      "gtfsStopId": "706",
+      "latitude": 40.749865,
+      "longitude": -73.8627
     },
     {
       "display": "Junction Boulevard",
-      "name": "Junction Blvd"
+      "name": "Junction Blvd",
+      "gtfsStopId": "707",
+      "latitude": 40.749145,
+      "longitude": -73.869527
     },
     {
       "display": "90th Street-Elmhurst Avenue",
-      "name": "90 St-Elmhurst Av"
+      "name": "90 St-Elmhurst Av",
+      "gtfsStopId": "708",
+      "latitude": 40.748408,
+      "longitude": -73.876613
     },
     {
       "display": "82nd Street-Jackson Heights",
-      "name": "82 St-Jackson Hts"
+      "name": "82 St-Jackson Hts",
+      "gtfsStopId": "709",
+      "latitude": 40.747659,
+      "longitude": -73.883697
     },
     {
       "display": "74th Street-Broadway",
-      "name": "Roosevelt Av / 74 St-Broadway"
+      "name": "74 St-Broadway",
+      "gtfsStopId": "710",
+      "latitude": 40.746848,
+      "longitude": -73.891394
     },
     {
       "display": "69th Street",
-      "name": "69 St"
+      "name": "69 St",
+      "gtfsStopId": "711",
+      "latitude": 40.746325,
+      "longitude": -73.896403
     },
     {
       "display": "61st Street-Woodside",
-      "name": "61 St-Woodside"
+      "name": "61 St-Woodside",
+      "gtfsStopId": "712",
+      "latitude": 40.74563,
+      "longitude": -73.902984
     },
     {
       "display": "52nd Street",
-      "name": "52 St"
+      "name": "52 St",
+      "gtfsStopId": "713",
+      "latitude": 40.744149,
+      "longitude": -73.912549
     },
     {
       "display": "46th Street-Bliss Street",
-      "name": "46 St-Bliss St"
+      "name": "46 St-Bliss St",
+      "gtfsStopId": "714",
+      "latitude": 40.743132,
+      "longitude": -73.918435
     },
     {
       "display": "40th Street-Lowery Street",
-      "name": "40 St-Lowery St"
+      "name": "40 St-Lowery St",
+      "gtfsStopId": "715",
+      "latitude": 40.743781,
+      "longitude": -73.924016
     },
     {
       "display": "33rd Street-Rawson Street",
-      "name": "33 St-Rawson St"
+      "name": "33 St-Rawson St",
+      "gtfsStopId": "716",
+      "latitude": 40.744587,
+      "longitude": -73.930997
     },
     {
       "display": "Queensboro Plaza",
-      "name": "Queensboro Plaza"
+      "name": "Queensboro Plaza",
+      "gtfsStopId": "718",
+      "latitude": 40.750582,
+      "longitude": -73.940202
     },
     {
       "display": "Court Square",
-      "name": "Court Sq-23 St"
+      "name": "Court Sq-23 St",
+      "gtfsStopId": "719",
+      "latitude": 40.747023,
+      "longitude": -73.945264
     },
     {
       "display": "Hunters Point Avenue",
-      "name": "Hunters Point Av"
+      "name": "Hunters Point Av",
+      "gtfsStopId": "720",
+      "latitude": 40.742216,
+      "longitude": -73.948916
     },
     {
       "display": "Vernon Boulevard-Jackson Avenue",
-      "name": "Vernon Blvd-Jackson Av"
+      "name": "Vernon Blvd-Jackson Av",
+      "gtfsStopId": "721",
+      "latitude": 40.742626,
+      "longitude": -73.953581
     },
     {
       "display": "Grand Central-42nd Street",
-      "name": "Grand Central-42 St"
+      "name": "Grand Central-42 St",
+      "gtfsStopId": "723",
+      "latitude": 40.751431,
+      "longitude": -73.976041
     },
     {
       "display": "5th Avenue",
-      "name": "5 Av"
+      "name": "5 Av",
+      "gtfsStopId": "724",
+      "latitude": 40.753821,
+      "longitude": -73.981963
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "725",
+      "latitude": 40.755477,
+      "longitude": -73.987691
     },
     {
       "display": "34th Street-Hudson Yards",
-      "name": "34 St-Hudson Yards"
+      "name": "34 St-Hudson Yards",
+      "gtfsStopId": "726",
+      "latitude": 40.755882,
+      "longitude": -74.00191
     }
   ],
   "A": [
     {
       "display": "Inwood-207th Street",
-      "name": "Inwood-207 St"
+      "name": "Inwood-207 St",
+      "gtfsStopId": "A02",
+      "latitude": 40.868072,
+      "longitude": -73.919899
     },
     {
       "display": "Dyckman Street",
-      "name": "Dyckman St"
+      "name": "Dyckman St",
+      "gtfsStopId": "A03",
+      "latitude": 40.865491,
+      "longitude": -73.927271
     },
     {
       "display": "190th Street",
-      "name": "190 St"
+      "name": "190 St",
+      "gtfsStopId": "A05",
+      "latitude": 40.859022,
+      "longitude": -73.93418
     },
     {
       "display": "181st Street",
-      "name": "181 St"
+      "name": "181 St",
+      "gtfsStopId": "A06",
+      "latitude": 40.851695,
+      "longitude": -73.937969
     },
     {
       "display": "175th Street",
-      "name": "175 St"
+      "name": "175 St",
+      "gtfsStopId": "A07",
+      "latitude": 40.847391,
+      "longitude": -73.939704
     },
     {
       "display": "168th Street",
-      "name": "168 St-Washington Hts"
+      "name": "168 St-Washington Hts",
+      "gtfsStopId": "A09",
+      "latitude": 40.840719,
+      "longitude": -73.939561
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "A12",
+      "latitude": 40.824783,
+      "longitude": -73.944216
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "A15",
+      "latitude": 40.811109,
+      "longitude": -73.952343
     },
     {
       "display": "59th Street-Columbus Circle",
-      "name": "59 St-Columbus Circle"
+      "name": "59 St-Columbus Circle",
+      "gtfsStopId": "A24",
+      "latitude": 40.768296,
+      "longitude": -73.981736
     },
     {
       "display": "42nd Street-Port Authority Bus Terminal",
-      "name": "42 St-Port Authority Bus Terminal"
+      "name": "42 St-Port Authority Bus Terminal",
+      "gtfsStopId": "A27",
+      "latitude": 40.757308,
+      "longitude": -73.989735
     },
     {
       "display": "34th Street-Penn Station",
-      "name": "34 St-Penn Station"
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "A28",
+      "latitude": 40.752287,
+      "longitude": -73.993391
     },
     {
       "display": "23rd Street",
-      "name": "23 St"
+      "name": "23 St",
+      "gtfsStopId": "A30",
+      "latitude": 40.745906,
+      "longitude": -73.998041
     },
     {
       "display": "14th Street",
-      "name": "14 St / 8 Av"
+      "name": "14 St / 8 Av",
+      "gtfsStopId": "A31",
+      "latitude": 40.740893,
+      "longitude": -74.00169
     },
     {
       "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "A32",
+      "latitude": 40.732338,
+      "longitude": -74.000495
     },
     {
       "display": "Spring Street",
-      "name": "Spring St"
+      "name": "Spring St",
+      "gtfsStopId": "A33",
+      "latitude": 40.726227,
+      "longitude": -74.003739
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "A34",
+      "latitude": 40.720824,
+      "longitude": -74.005229
     },
     {
       "display": "Chambers Street",
-      "name": "Chambers St"
+      "name": "Chambers St",
+      "gtfsStopId": "A36",
+      "latitude": 40.714111,
+      "longitude": -74.008585
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "A38",
+      "latitude": 40.710197,
+      "longitude": -74.007691
     },
     {
       "display": "High Street",
-      "name": "High St"
+      "name": "High St",
+      "gtfsStopId": "A40",
+      "latitude": 40.699337,
+      "longitude": -73.990531
     },
     {
       "display": "Jay Street-MetroTech",
-      "name": "Jay St-MetroTech"
+      "name": "Jay St-MetroTech",
+      "gtfsStopId": "A41",
+      "latitude": 40.692338,
+      "longitude": -73.987342
     },
     {
       "display": "Hoyt-Schermerhorn Streets",
-      "name": "Hoyt-Schermerhorn Sts"
+      "name": "Hoyt-Schermerhorn Sts",
+      "gtfsStopId": "A42",
+      "latitude": 40.688484,
+      "longitude": -73.985001
     },
     {
       "display": "Lafayette Avenue",
-      "name": "Lafayette Av"
+      "name": "Lafayette Av",
+      "gtfsStopId": "A43",
+      "latitude": 40.686113,
+      "longitude": -73.973946
     },
     {
       "display": "Clinton-Washington Avenues",
-      "name": "Clinton-Washington Avs"
+      "name": "Clinton-Washington Avs",
+      "gtfsStopId": "A44",
+      "latitude": 40.683263,
+      "longitude": -73.965838
     },
     {
       "display": "Franklin Avenue",
-      "name": "Franklin Av"
+      "name": "Franklin Av",
+      "gtfsStopId": "A45",
+      "latitude": 40.68138,
+      "longitude": -73.956848
     },
     {
       "display": "Nostrand Avenue",
-      "name": "Nostrand Av"
+      "name": "Nostrand Av",
+      "gtfsStopId": "A46",
+      "latitude": 40.680438,
+      "longitude": -73.950426
     },
     {
       "display": "Utica Avenue",
-      "name": "Utica Av"
+      "name": "Utica Av",
+      "gtfsStopId": "A48",
+      "latitude": 40.679364,
+      "longitude": -73.930729
     },
     {
       "display": "Broadway Junction",
-      "name": "Broadway Junction"
+      "name": "Broadway Junction",
+      "gtfsStopId": "A51",
+      "latitude": 40.678334,
+      "longitude": -73.905316
     },
     {
       "display": "Liberty Avenue",
-      "name": "Liberty Av"
+      "name": "Liberty Av",
+      "gtfsStopId": "A52",
+      "latitude": 40.674542,
+      "longitude": -73.896548
     },
     {
       "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
+      "name": "Van Siclen Av",
+      "gtfsStopId": "A53",
+      "latitude": 40.67271,
+      "longitude": -73.890358
     },
     {
       "display": "Shepherd Avenue",
-      "name": "Shepherd Av"
+      "name": "Shepherd Av",
+      "gtfsStopId": "A54",
+      "latitude": 40.67413,
+      "longitude": -73.88075
     },
     {
       "display": "Euclid Avenue",
-      "name": "Euclid Av"
+      "name": "Euclid Av",
+      "gtfsStopId": "A55",
+      "latitude": 40.675377,
+      "longitude": -73.872106
     },
     {
       "display": "Grant Avenue",
-      "name": "Grant Av"
+      "name": "Grant Av",
+      "gtfsStopId": "A57",
+      "latitude": 40.677044,
+      "longitude": -73.86505
     },
     {
       "display": "80th Street",
-      "name": "80 St"
+      "name": "80 St",
+      "gtfsStopId": "A59",
+      "latitude": 40.679371,
+      "longitude": -73.858992
     },
     {
       "display": "88th Street",
-      "name": "88 St"
+      "name": "88 St",
+      "gtfsStopId": "A60",
+      "latitude": 40.679843,
+      "longitude": -73.85147
     },
     {
       "display": "Rockaway Boulevard",
-      "name": "Rockaway Blvd"
-    },
-    {
-      "display": "104th Street",
-      "name": "104 St"
-    },
-    {
-      "display": "111th Street",
-      "name": "111 St"
-    },
-    {
-      "display": "Ozone Park-Lefferts Boulevard",
-      "name": "Ozone Park-Lefferts Blvd"
+      "name": "Rockaway Blvd",
+      "gtfsStopId": "A61",
+      "latitude": 40.680429,
+      "longitude": -73.843853
     },
     {
       "display": "Aqueduct Racetrack",
-      "name": "Aqueduct Racetrack"
+      "name": "Aqueduct Racetrack",
+      "gtfsStopId": "H01",
+      "latitude": 40.672097,
+      "longitude": -73.835919
+    },
+    {
+      "display": "Aqueduct-North Conduit Avenue",
+      "name": "Aqueduct-N Conduit Av",
+      "gtfsStopId": "H02",
+      "latitude": 40.668234,
+      "longitude": -73.834058
     },
     {
       "display": "Howard Beach-JFK Airport",
-      "name": "Howard Beach-JFK Airport"
+      "name": "Howard Beach-JFK Airport",
+      "gtfsStopId": "H03",
+      "latitude": 40.660476,
+      "longitude": -73.830301
     },
     {
       "display": "Broad Channel",
-      "name": "Broad Channel"
+      "name": "Broad Channel",
+      "gtfsStopId": "H04",
+      "latitude": 40.608382,
+      "longitude": -73.815925
     },
     {
       "display": "Beach 67th Street",
-      "name": "Beach 67 St"
+      "name": "Beach 67 St",
+      "gtfsStopId": "H06",
+      "latitude": 40.590927,
+      "longitude": -73.796924
     },
     {
       "display": "Beach 60th Street",
-      "name": "Beach 60 St"
+      "name": "Beach 60 St",
+      "gtfsStopId": "H07",
+      "latitude": 40.592374,
+      "longitude": -73.788522
     },
     {
       "display": "Beach 44th Street",
-      "name": "Beach 44 St"
+      "name": "Beach 44 St",
+      "gtfsStopId": "H08",
+      "latitude": 40.592943,
+      "longitude": -73.776013
     },
     {
       "display": "Beach 36th Street",
-      "name": "Beach 36 St"
+      "name": "Beach 36 St",
+      "gtfsStopId": "H09",
+      "latitude": 40.595398,
+      "longitude": -73.768175
     },
     {
       "display": "Beach 25th Street",
-      "name": "Beach 25 St"
+      "name": "Beach 25 St",
+      "gtfsStopId": "H10",
+      "latitude": 40.600066,
+      "longitude": -73.761353
     },
     {
       "display": "Far Rockaway-Mott Avenue",
-      "name": "Far Rockaway-Mott Av"
+      "name": "Far Rockaway-Mott Av",
+      "gtfsStopId": "H11",
+      "latitude": 40.603995,
+      "longitude": -73.755405
+    },
+    {
+      "display": "104th Street",
+      "name": "104 St",
+      "gtfsStopId": "A63",
+      "latitude": 40.681711,
+      "longitude": -73.837683
+    },
+    {
+      "display": "111th Street",
+      "name": "111 St",
+      "gtfsStopId": "A64",
+      "latitude": 40.684331,
+      "longitude": -73.832163
+    },
+    {
+      "display": "Ozone Park-Lefferts Boulevard",
+      "name": "Ozone Park-Lefferts Blvd",
+      "gtfsStopId": "A65",
+      "latitude": 40.685951,
+      "longitude": -73.825798
     }
   ],
   "B": [
     {
       "display": "Bedford Park Boulevard",
-      "name": "Bedford Park Blvd"
+      "name": "Bedford Park Blvd",
+      "gtfsStopId": "D03",
+      "latitude": 40.873244,
+      "longitude": -73.887138
     },
     {
       "display": "Kingsbridge Road",
-      "name": "Kingsbridge Rd"
+      "name": "Kingsbridge Rd",
+      "gtfsStopId": "D04",
+      "latitude": 40.866978,
+      "longitude": -73.893509
     },
     {
       "display": "Fordham Road",
-      "name": "Fordham Rd"
+      "name": "Fordham Rd",
+      "gtfsStopId": "D05",
+      "latitude": 40.861296,
+      "longitude": -73.897749
     },
     {
       "display": "183rd Street",
-      "name": "183 St"
+      "name": "183 St",
+      "gtfsStopId": "D06",
+      "latitude": 40.856093,
+      "longitude": -73.900741
     },
     {
       "display": "Tremont Avenue",
-      "name": "Tremont Av"
+      "name": "Tremont Av",
+      "gtfsStopId": "D07",
+      "latitude": 40.85041,
+      "longitude": -73.905227
     },
     {
       "display": "174th-175th Streets",
-      "name": "174-175 Sts"
+      "name": "174-175 Sts",
+      "gtfsStopId": "D08",
+      "latitude": 40.8459,
+      "longitude": -73.910136
     },
     {
       "display": "170th Street",
-      "name": "170 St"
+      "name": "170 St",
+      "gtfsStopId": "D09",
+      "latitude": 40.839306,
+      "longitude": -73.9134
     },
     {
       "display": "167th Street",
-      "name": "167 St"
+      "name": "167 St",
+      "gtfsStopId": "D10",
+      "latitude": 40.833771,
+      "longitude": -73.91844
     },
     {
       "display": "161st Street-Yankee Stadium",
-      "name": "161 St-Yankee Stadium"
+      "name": "161 St-Yankee Stadium",
+      "gtfsStopId": "D11",
+      "latitude": 40.827905,
+      "longitude": -73.925651
+    },
+    {
+      "display": "155th Street",
+      "name": "155 St",
+      "gtfsStopId": "D12",
+      "latitude": 40.830135,
+      "longitude": -73.938209
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "D13",
+      "latitude": 40.824783,
+      "longitude": -73.944216
     },
     {
       "display": "135th Street",
-      "name": "135 St"
+      "name": "135 St",
+      "gtfsStopId": "A14",
+      "latitude": 40.817894,
+      "longitude": -73.947649
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "A15",
+      "latitude": 40.811109,
+      "longitude": -73.952343
     },
     {
       "display": "116th Street",
-      "name": "116 St"
+      "name": "116 St",
+      "gtfsStopId": "A16",
+      "latitude": 40.805085,
+      "longitude": -73.954882
     },
     {
       "display": "Cathedral Parkway-110th Street",
-      "name": "Cathedral Pkwy (110 St)"
+      "name": "Cathedral Pkwy (110 St)",
+      "gtfsStopId": "A17",
+      "latitude": 40.800603,
+      "longitude": -73.958161
     },
     {
       "display": "103rd Street",
-      "name": "103 St"
+      "name": "103 St",
+      "gtfsStopId": "A18",
+      "latitude": 40.796092,
+      "longitude": -73.961454
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "A19",
+      "latitude": 40.791642,
+      "longitude": -73.964696
+    },
+    {
+      "display": "86th Street",
+      "name": "86 St",
+      "gtfsStopId": "A20",
+      "latitude": 40.785868,
+      "longitude": -73.968916
     },
     {
       "display": "81st Street-Museum of Natural History",
-      "name": "81 St-Museum of Natural History"
+      "name": "81 St-Museum of Natural History",
+      "gtfsStopId": "A21",
+      "latitude": 40.781433,
+      "longitude": -73.972143
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "A22",
+      "latitude": 40.775594,
+      "longitude": -73.97641
     },
     {
       "display": "59th Street-Columbus Circle",
-      "name": "59 St-Columbus Circle"
+      "name": "59 St-Columbus Circle",
+      "gtfsStopId": "A24",
+      "latitude": 40.768296,
+      "longitude": -73.981736
     },
     {
       "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "7 Av",
+      "gtfsStopId": "D14",
+      "latitude": 40.762862,
+      "longitude": -73.981637
     },
     {
       "display": "47th-50th Streets-Rockefeller Center",
-      "name": "47-50 Sts-Rockefeller Ctr"
+      "name": "47-50 Sts-Rockefeller Ctr",
+      "gtfsStopId": "D15",
+      "latitude": 40.758663,
+      "longitude": -73.981329
     },
     {
       "display": "42nd Street-Bryant Park",
-      "name": "42 St-Bryant Pk"
+      "name": "42 St-Bryant Pk",
+      "gtfsStopId": "D16",
+      "latitude": 40.754222,
+      "longitude": -73.984569
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "D17",
+      "latitude": 40.749719,
+      "longitude": -73.987823
     },
     {
       "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "D20",
+      "latitude": 40.732338,
+      "longitude": -74.000495
     },
     {
       "display": "Broadway-Lafayette Street",
-      "name": "Bleecker St / Broadway-Lafayette St"
+      "name": "Bleecker St / Broadway-Lafayette St",
+      "gtfsStopId": "D21",
+      "latitude": 40.725297,
+      "longitude": -73.996204
     },
     {
       "display": "Grand Street",
-      "name": "Grand St"
+      "name": "Grand St",
+      "gtfsStopId": "D22",
+      "latitude": 40.718267,
+      "longitude": -73.993753
     },
     {
       "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
+      "name": "DeKalb Av",
+      "gtfsStopId": "R30",
+      "latitude": 40.690635,
+      "longitude": -73.981824
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "D24",
+      "latitude": 40.68446,
+      "longitude": -73.97689
     },
     {
       "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "7 Av",
+      "gtfsStopId": "D25",
+      "latitude": 40.67705,
+      "longitude": -73.972367
+    },
+    {
+      "display": "7th Avenue",
+      "name": "7 Av",
+      "gtfsStopId": "D25",
+      "latitude": 40.67705,
+      "longitude": -73.972367
     },
     {
       "display": "Prospect Park",
-      "name": "Prospect Park"
+      "name": "Prospect Park",
+      "gtfsStopId": "D26",
+      "latitude": 40.661614,
+      "longitude": -73.962246
     },
     {
       "display": "Church Avenue",
-      "name": "Church Av"
+      "name": "Church Av",
+      "gtfsStopId": "D28",
+      "latitude": 40.650527,
+      "longitude": -73.962982
     },
     {
       "display": "Newkirk Plaza",
-      "name": "Newkirk Plaza"
+      "name": "Newkirk Plaza",
+      "gtfsStopId": "D31",
+      "latitude": 40.635082,
+      "longitude": -73.962793
     },
     {
       "display": "Kings Highway",
-      "name": "Kings Hwy"
+      "name": "Kings Hwy",
+      "gtfsStopId": "D35",
+      "latitude": 40.60867,
+      "longitude": -73.957734
     },
     {
       "display": "Sheepshead Bay",
-      "name": "Sheepshead Bay"
+      "name": "Sheepshead Bay",
+      "gtfsStopId": "D39",
+      "latitude": 40.586896,
+      "longitude": -73.954155
     },
     {
       "display": "Brighton Beach",
-      "name": "Brighton Beach"
+      "name": "Brighton Beach",
+      "gtfsStopId": "D40",
+      "latitude": 40.577621,
+      "longitude": -73.961376
     }
   ],
   "C": [
     {
       "display": "168th Street",
-      "name": "168 St"
+      "name": "168 St",
+      "gtfsStopId": "A09",
+      "latitude": 40.840719,
+      "longitude": -73.939561
     },
     {
       "display": "163rd Street-Amsterdam Avenue",
-      "name": "163 St-Amsterdam Av"
+      "name": "163 St-Amsterdam Av",
+      "gtfsStopId": "A10",
+      "latitude": 40.836013,
+      "longitude": -73.939892
     },
     {
       "display": "155th Street",
-      "name": "155 St"
+      "name": "155 St",
+      "gtfsStopId": "A11",
+      "latitude": 40.830518,
+      "longitude": -73.941514
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "A12",
+      "latitude": 40.824783,
+      "longitude": -73.944216
     },
     {
       "display": "135th Street",
-      "name": "135 St"
+      "name": "135 St",
+      "gtfsStopId": "A14",
+      "latitude": 40.817894,
+      "longitude": -73.947649
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "A15",
+      "latitude": 40.811109,
+      "longitude": -73.952343
     },
     {
       "display": "116th Street",
-      "name": "116 St"
+      "name": "116 St",
+      "gtfsStopId": "A16",
+      "latitude": 40.805085,
+      "longitude": -73.954882
     },
     {
       "display": "Cathedral Parkway-110th Street",
-      "name": "Cathedral Pkwy (110 St)"
+      "name": "Cathedral Pkwy (110 St)",
+      "gtfsStopId": "A17",
+      "latitude": 40.800603,
+      "longitude": -73.958161
     },
     {
       "display": "103rd Street",
-      "name": "103 St"
+      "name": "103 St",
+      "gtfsStopId": "A18",
+      "latitude": 40.796092,
+      "longitude": -73.961454
     },
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "A19",
+      "latitude": 40.791642,
+      "longitude": -73.964696
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "A20",
+      "latitude": 40.785868,
+      "longitude": -73.968916
     },
     {
       "display": "81st Street-Museum of Natural History",
-      "name": "81 St-Museum of Natural History"
+      "name": "81 St-Museum of Natural History",
+      "gtfsStopId": "A21",
+      "latitude": 40.781433,
+      "longitude": -73.972143
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "A22",
+      "latitude": 40.775594,
+      "longitude": -73.97641
     },
     {
       "display": "59th Street-Columbus Circle",
-      "name": "59 St-Columbus Circle"
+      "name": "59 St-Columbus Circle",
+      "gtfsStopId": "A24",
+      "latitude": 40.768296,
+      "longitude": -73.981736
     },
     {
       "display": "50th Street",
-      "name": "50 St"
+      "name": "50 St",
+      "gtfsStopId": "A25",
+      "latitude": 40.762456,
+      "longitude": -73.985984
     },
     {
       "display": "42nd Street-Port Authority Bus Terminal",
-      "name": "42 St-Port Authority Bus Terminal"
+      "name": "42 St-Port Authority Bus Terminal",
+      "gtfsStopId": "A27",
+      "latitude": 40.757308,
+      "longitude": -73.989735
     },
     {
       "display": "34th Street-Penn Station",
-      "name": "34 St-Penn Station"
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "A28",
+      "latitude": 40.752287,
+      "longitude": -73.993391
     },
     {
       "display": "23rd Street",
-      "name": "23 St"
+      "name": "23 St",
+      "gtfsStopId": "A30",
+      "latitude": 40.745906,
+      "longitude": -73.998041
     },
     {
       "display": "14th Street",
-      "name": "14 St"
+      "name": "14 St",
+      "gtfsStopId": "A31",
+      "latitude": 40.740893,
+      "longitude": -74.00169
     },
     {
       "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "A32",
+      "latitude": 40.732338,
+      "longitude": -74.000495
     },
     {
       "display": "Spring Street",
-      "name": "Spring St"
+      "name": "Spring St",
+      "gtfsStopId": "A33",
+      "latitude": 40.726227,
+      "longitude": -74.003739
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "A34",
+      "latitude": 40.720824,
+      "longitude": -74.005229
     },
     {
       "display": "Chambers Street",
-      "name": "Chambers St"
+      "name": "Chambers St",
+      "gtfsStopId": "A36",
+      "latitude": 40.714111,
+      "longitude": -74.008585
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "A38",
+      "latitude": 40.710197,
+      "longitude": -74.007691
     },
     {
       "display": "High Street",
-      "name": "High St"
+      "name": "High St",
+      "gtfsStopId": "A40",
+      "latitude": 40.699337,
+      "longitude": -73.990531
     },
     {
       "display": "Jay Street-MetroTech",
-      "name": "Jay St-MetroTech"
+      "name": "Jay St-MetroTech",
+      "gtfsStopId": "A41",
+      "latitude": 40.692338,
+      "longitude": -73.987342
     },
     {
       "display": "Hoyt-Schermerhorn Streets",
-      "name": "Hoyt-Schermerhorn Sts"
+      "name": "Hoyt-Schermerhorn Sts",
+      "gtfsStopId": "A42",
+      "latitude": 40.688484,
+      "longitude": -73.985001
     },
     {
       "display": "Lafayette Avenue",
-      "name": "Lafayette Av"
+      "name": "Lafayette Av",
+      "gtfsStopId": "A43",
+      "latitude": 40.686113,
+      "longitude": -73.973946
     },
     {
       "display": "Clinton-Washington Avenues",
-      "name": "Clinton-Washington Avs"
+      "name": "Clinton-Washington Avs",
+      "gtfsStopId": "A44",
+      "latitude": 40.683263,
+      "longitude": -73.965838
     },
     {
       "display": "Franklin Avenue",
-      "name": "Franklin Av"
+      "name": "Franklin Av",
+      "gtfsStopId": "A45",
+      "latitude": 40.68138,
+      "longitude": -73.956848
     },
     {
       "display": "Nostrand Avenue",
-      "name": "Nostrand Av"
+      "name": "Nostrand Av",
+      "gtfsStopId": "A46",
+      "latitude": 40.680438,
+      "longitude": -73.950426
     },
     {
       "display": "Kingston-Throop Avenues",
-      "name": "Kingston-Throop Avs"
+      "name": "Kingston-Throop Avs",
+      "gtfsStopId": "A47",
+      "latitude": 40.679921,
+      "longitude": -73.940858
     },
     {
       "display": "Utica Avenue",
-      "name": "Utica Av"
+      "name": "Utica Av",
+      "gtfsStopId": "A48",
+      "latitude": 40.679364,
+      "longitude": -73.930729
     },
     {
       "display": "Ralph Avenue",
-      "name": "Ralph Av"
+      "name": "Ralph Av",
+      "gtfsStopId": "A49",
+      "latitude": 40.678822,
+      "longitude": -73.920786
     },
     {
       "display": "Rockaway Avenue",
-      "name": "Rockaway Av"
+      "name": "Rockaway Av",
+      "gtfsStopId": "A50",
+      "latitude": 40.67834,
+      "longitude": -73.911946
     },
     {
       "display": "Broadway Junction",
-      "name": "Broadway Junction"
+      "name": "Broadway Junction",
+      "gtfsStopId": "A51",
+      "latitude": 40.678334,
+      "longitude": -73.905316
     },
     {
       "display": "Liberty Avenue",
-      "name": "Liberty Av"
+      "name": "Liberty Av",
+      "gtfsStopId": "A52",
+      "latitude": 40.674542,
+      "longitude": -73.896548
     },
     {
       "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
+      "name": "Van Siclen Av",
+      "gtfsStopId": "A53",
+      "latitude": 40.67271,
+      "longitude": -73.890358
     },
     {
       "display": "Shepherd Avenue",
-      "name": "Shepherd Av"
+      "name": "Shepherd Av",
+      "gtfsStopId": "A54",
+      "latitude": 40.67413,
+      "longitude": -73.88075
     },
     {
       "display": "Euclid Avenue",
-      "name": "Euclid Av"
+      "name": "Euclid Av",
+      "gtfsStopId": "A55",
+      "latitude": 40.675377,
+      "longitude": -73.872106
     }
   ],
   "D": [
     {
       "display": "Norwood-205th Street",
-      "name": "Norwood-205 St"
+      "name": "Norwood-205 St",
+      "gtfsStopId": "D01",
+      "latitude": 40.874811,
+      "longitude": -73.878855
     },
     {
       "display": "Bedford Park Boulevard",
-      "name": "Bedford Park Blvd"
+      "name": "Bedford Park Blvd",
+      "gtfsStopId": "D03",
+      "latitude": 40.873244,
+      "longitude": -73.887138
     },
     {
       "display": "Kingsbridge Road",
-      "name": "Kingsbridge Rd"
+      "name": "Kingsbridge Rd",
+      "gtfsStopId": "D04",
+      "latitude": 40.866978,
+      "longitude": -73.893509
     },
     {
       "display": "Fordham Road",
-      "name": "Fordham Rd"
+      "name": "Fordham Rd",
+      "gtfsStopId": "D05",
+      "latitude": 40.861296,
+      "longitude": -73.897749
     },
     {
       "display": "182nd-183rd Streets",
-      "name": "182-183 Sts"
+      "name": "182-183 Sts",
+      "gtfsStopId": "D06",
+      "latitude": 40.856093,
+      "longitude": -73.900741
     },
     {
       "display": "Tremont Avenue",
-      "name": "Tremont Av"
+      "name": "Tremont Av",
+      "gtfsStopId": "D07",
+      "latitude": 40.85041,
+      "longitude": -73.905227
     },
     {
       "display": "174th-175th Streets",
-      "name": "174-175 Sts"
+      "name": "174-175 Sts",
+      "gtfsStopId": "D08",
+      "latitude": 40.8459,
+      "longitude": -73.910136
     },
     {
       "display": "170th Street",
-      "name": "170 St"
+      "name": "170 St",
+      "gtfsStopId": "D09",
+      "latitude": 40.839306,
+      "longitude": -73.9134
     },
     {
       "display": "167th Street",
-      "name": "167 St"
+      "name": "167 St",
+      "gtfsStopId": "D10",
+      "latitude": 40.833771,
+      "longitude": -73.91844
     },
     {
       "display": "161st Street-Yankee Stadium",
-      "name": "161 St-Yankee Stadium"
+      "name": "161 St-Yankee Stadium",
+      "gtfsStopId": "D11",
+      "latitude": 40.827905,
+      "longitude": -73.925651
     },
     {
       "display": "155th Street",
-      "name": "155 St"
+      "name": "155 St",
+      "gtfsStopId": "D12",
+      "latitude": 40.830135,
+      "longitude": -73.938209
     },
     {
       "display": "145th Street",
-      "name": "145 St"
+      "name": "145 St",
+      "gtfsStopId": "D13",
+      "latitude": 40.824783,
+      "longitude": -73.944216
     },
     {
       "display": "125th Street",
-      "name": "125 St"
+      "name": "125 St",
+      "gtfsStopId": "A15",
+      "latitude": 40.811109,
+      "longitude": -73.952343
     },
     {
       "display": "59th Street-Columbus Circle",
-      "name": "59 St-Columbus Circle"
+      "name": "59 St-Columbus Circle",
+      "gtfsStopId": "A24",
+      "latitude": 40.768296,
+      "longitude": -73.981736
     },
     {
       "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "7 Av",
+      "gtfsStopId": "D14",
+      "latitude": 40.762862,
+      "longitude": -73.981637
+    },
+    {
+      "display": "7th Avenue",
+      "name": "7 Av",
+      "gtfsStopId": "D14",
+      "latitude": 40.762862,
+      "longitude": -73.981637
     },
     {
       "display": "47th-50th Streets-Rockefeller Center",
-      "name": "47-50 Sts-Rockefeller Ctr"
+      "name": "47-50 Sts-Rockefeller Ctr",
+      "gtfsStopId": "D15",
+      "latitude": 40.758663,
+      "longitude": -73.981329
     },
     {
       "display": "42nd Street-Bryant Park",
-      "name": "42 St-Bryant Pk"
+      "name": "42 St-Bryant Pk",
+      "gtfsStopId": "D16",
+      "latitude": 40.754222,
+      "longitude": -73.984569
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "D17",
+      "latitude": 40.749719,
+      "longitude": -73.987823
     },
     {
       "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "D20",
+      "latitude": 40.732338,
+      "longitude": -74.000495
     },
     {
       "display": "Broadway-Lafayette Street",
-      "name": "Bleecker St / Broadway-Lafayette St"
+      "name": "Bleecker St / Broadway-Lafayette St",
+      "gtfsStopId": "D21",
+      "latitude": 40.725297,
+      "longitude": -73.996204
     },
     {
       "display": "Grand Street",
-      "name": "Grand St"
+      "name": "Grand St",
+      "gtfsStopId": "D22",
+      "latitude": 40.718267,
+      "longitude": -73.993753
     },
     {
       "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
+      "name": "DeKalb Av",
+      "gtfsStopId": "R30",
+      "latitude": 40.690635,
+      "longitude": -73.981824
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
-    },
-    {
-      "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "R31",
+      "latitude": 40.683666,
+      "longitude": -73.97881
     },
     {
       "display": "Prospect Park",
-      "name": "15 St-Prospect Park"
+      "name": "15 St-Prospect Park",
+      "gtfsStopId": "D26",
+      "latitude": 40.661614,
+      "longitude": -73.962246
+    },
+    {
+      "display": "36th Street",
+      "name": "36 St",
+      "gtfsStopId": "R36",
+      "latitude": 40.655144,
+      "longitude": -74.003549
     },
     {
       "display": "Church Avenue",
-      "name": "Church Av"
+      "name": "Church Av",
+      "gtfsStopId": "D28",
+      "latitude": 40.650527,
+      "longitude": -73.962982
     },
     {
-      "display": "Ditmas Avenue",
-      "name": "Ditmas Av"
-    },
-    {
-      "display": "18th Avenue",
-      "name": "18 Av"
-    },
-    {
-      "display": "20th Avenue",
-      "name": "20 Av"
-    },
-    {
-      "display": "Bay Parkway",
-      "name": "Bay Pkwy"
-    },
-    {
-      "display": "25th Avenue",
-      "name": "86 St"
-    },
-    {
-      "display": "Bay 50th Street",
-      "name": "50 St"
-    },
-    {
-      "display": "Coney Island-Stillwell Avenue",
-      "name": "Coney Island-Stillwell Av"
-    }
-  ],
-  "E": [
-  {
-    "display": "Jamaica Center-Parsons/Archer",
-    "name": "Jamaica Center-Parsons/Archer"
-  },
-  {
-    "display": "Sutphin Boulevard-Archer Avenue-JFK Airport",
-    "name": "Sutphin Blvd-Archer Av-JFK Airport"
-  },
-  {
-    "display": "Jamaica-Van Wyck",
-    "name": "Jamaica-Van Wyck"
-  },
-  {
-    "display": "Briarwood",
-    "name": "Briarwood"
-  },
-  {
-    "display": "Kew Gardens-Union Turnpike",
-    "name": "Kew Gardens-Union Tpke"
-  },
-  {
-    "display": "75th Avenue",
-    "name": "75 Av"
-  },
-  {
-    "display": "Forest Hills-71st Avenue",
-    "name": "Forest Hills-71 Av"
-  },
-  {
-    "display": "67th Avenue",
-    "name": "67 Av"
-  },
-  {
-    "display": "63rd Drive-Rego Park",
-    "name": "63 Dr-Rego Park"
-  },
-  {
-    "display": "Woodhaven Boulevard",
-    "name": "Woodhaven Blvd"
-  },
-  {
-    "display": "Grand Avenue-Newtown",
-    "name": "Grand Av-Newtown"
-  },
-  {
-    "display": "Elmhurst Avenue",
-    "name": "Elmhurst Av"
-  },
-  {
-    "display": "Jackson Heights-Roosevelt Avenue",
-    "name": "Roosevelt Av / 74 St-Broadway"
-  },
-  {
-    "display": "65th Street",
-    "name": "65 St"
-  },
-  {
-    "display": "Northern Boulevard",
-    "name": "Northern Blvd"
-  },
-  {
-    "display": "46th Street",
-    "name": "46 St"
-  },
-  {
-    "display": "Steinway Street",
-    "name": "Steinway St"
-  },
-  {
-    "display": "36th Street",
-    "name": "36 St"
-  },
-  {
-    "display": "Court Square-23rd Street",
-    "name": "Court Sq-23 St"
-  },
-  {
-    "display": "Queens Plaza",
-    "name": "Queens Plaza"
-  },
-  {
-    "display": "Lexington Avenue-53rd Street",
-    "name": "51 St / Lexington Av/53 St"
-  },
-  {
-    "display": "5th Avenue-53rd Street",
-    "name": "5 Av/53 St"
-  },
-  {
-    "display": "7th Avenue",
-    "name": "7 Av"
-  },
-  {
-    "display": "50th Street",
-    "name": "50 St"
-  },
-  {
-    "display": "42nd Street-Port Authority Bus Terminal",
-    "name": "42 St-Port Authority Bus Terminal"
-  },
-  {
-    "display": "34th Street-Penn Station",
-    "name": "34 St-Penn Station"
-  },
-  {
-    "display": "23rd Street",
-    "name": "23 St"
-  },
-  {
-    "display": "14th Street",
-    "name": "14 St / 8 Av"
-  },
-  {
-    "display": "Spring Street",
-    "name": "Spring St"
-  },
-  {
-    "display": "World Trade Center",
-    "name": "World Trade Center"
-  }
-],
-  "F": [
-    {
-      "display": "Jamaica-179th Street",
-      "name": "Jamaica-179 St"
-    },
-    {
-      "display": "169th Street",
-      "name": "169 St"
-    },
-    {
-      "display": "Parsons Boulevard",
-      "name": "Parsons Blvd"
-    },
-    {
-      "display": "Sutphin Boulevard",
-      "name": "Sutphin Blvd"
-    },
-    {
-      "display": "Briarwood",
-      "name": "Briarwood"
-    },
-    {
-      "display": "Kew Gardens-Union Turnpike",
-      "name": "Kew Gardens-Union Tpke"
-    },
-    {
-      "display": "75th Avenue",
-      "name": "75 Av"
-    },
-    {
-      "display": "Forest Hills-71st Avenue",
-      "name": "Forest Hills-71 Av"
-    },
-    {
-      "display": "Jackson Heights-Roosevelt Avenue",
-      "name": "Roosevelt Av / 74 St-Broadway"
-    },
-    {
-      "display": "21st Street-Queensbridge",
-      "name": "21 St-Queensbridge"
-    },
-    {
-      "display": "Roosevelt Island",
-      "name": "Roosevelt Island"
-    },
-    {
-      "display": "Lexington Avenue-63rd Street",
-      "name": "Lexington Av/63 St"
-    },
-    {
-      "display": "57th Street",
-      "name": "57 St"
-    },
-    {
-      "display": "47th-50th Streets-Rockefeller Center",
-      "name": "47-50 Sts-Rockefeller Ctr"
-    },
-    {
-      "display": "42nd Street-Bryant Park",
-      "name": "42 St-Bryant Pk"
-    },
-    {
-      "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
-    },
-    {
-      "display": "23rd Street",
-      "name": "23 St"
-    },
-    {
-      "display": "14th Street",
-      "name": "14 St / 6 Av"
-    },
-    {
-      "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
-    },
-    {
-      "display": "Broadway-Lafayette Street",
-      "name": "Bleecker St / Broadway-Lafayette St"
-    },
-    {
-      "display": "2nd Avenue",
-      "name": "2 Av"
-    },
-    {
-      "display": "Delancey Street-Essex Street",
-      "name": "Delancey St-Essex St"
-    },
-    {
-      "display": "East Broadway",
-      "name": "East Broadway"
-    },
-    {
-      "display": "York Street",
-      "name": "York St"
-    },
-    {
-      "display": "Jay Street-MetroTech",
-      "name": "Jay St-MetroTech"
-    },
-    {
-      "display": "Bergen Street",
-      "name": "Bergen St"
-    },
-    {
-      "display": "Carroll Street",
-      "name": "Carroll St"
-    },
-    {
-      "display": "Smith-9th Streets",
-      "name": "Smith-9 Sts"
-    },
-    {
-      "display": "4th Avenue-9th Street",
-      "name": "4 Av-9 St"
-    },
-    {
-      "display": "7th Avenue",
-      "name": "7 Av"
-    },
-    {
-      "display": "15th Street-Prospect Park",
-      "name": "15 St-Prospect Park"
+      "display": "9th Avenue",
+      "name": "9 Av",
+      "gtfsStopId": "B12",
+      "latitude": 40.646292,
+      "longitude": -73.994324
     },
     {
       "display": "Fort Hamilton Parkway",
-      "name": "Fort Hamilton Pkwy"
+      "name": "Fort Hamilton Pkwy",
+      "gtfsStopId": "B13",
+      "latitude": 40.640914,
+      "longitude": -73.994304
     },
     {
-      "display": "Church Avenue",
-      "name": "Church Av"
+      "display": "Bay 50th Street",
+      "name": "50 St",
+      "gtfsStopId": "B14",
+      "latitude": 40.63626,
+      "longitude": -73.994791
     },
     {
-      "display": "Ditmas Avenue",
-      "name": "Ditmas Av"
+      "display": "55th Street",
+      "name": "55 St",
+      "gtfsStopId": "B15",
+      "latitude": 40.631435,
+      "longitude": -73.995476
+    },
+    {
+      "display": "62nd Street",
+      "name": "62 St",
+      "gtfsStopId": "B16",
+      "latitude": 40.626472,
+      "longitude": -73.996895
+    },
+    {
+      "display": "71st Street",
+      "name": "71 St",
+      "gtfsStopId": "B17",
+      "latitude": 40.619589,
+      "longitude": -73.998864
+    },
+    {
+      "display": "79th Street",
+      "name": "79 St",
+      "gtfsStopId": "B18",
+      "latitude": 40.613501,
+      "longitude": -74.00061
     },
     {
       "display": "18th Avenue",
-      "name": "18 Av"
+      "name": "18 Av",
+      "gtfsStopId": "B19",
+      "latitude": 40.607954,
+      "longitude": -74.001736
     },
     {
-      "display": "Avenue I",
-      "name": "Avenue I"
+      "display": "20th Avenue",
+      "name": "20 Av",
+      "gtfsStopId": "B20",
+      "latitude": 40.604556,
+      "longitude": -73.998168
     },
     {
       "display": "Bay Parkway",
-      "name": "Bay Pkwy"
+      "name": "Bay Pkwy",
+      "gtfsStopId": "B21",
+      "latitude": 40.601875,
+      "longitude": -73.993728
     },
     {
-      "display": "Avenue N",
-      "name": "Avenue N"
+      "display": "25th Avenue",
+      "name": "86 St",
+      "gtfsStopId": "B22",
+      "latitude": 40.597704,
+      "longitude": -73.986829
     },
     {
-      "display": "Avenue P",
-      "name": "Avenue P"
-    },
-    {
-      "display": "Kings Highway",
-      "name": "Kings Hwy"
-    },
-    {
-      "display": "Avenue U",
-      "name": "Avenue U"
-    },
-    {
-      "display": "Avenue X",
-      "name": "Avenue X"
-    },
-    {
-      "display": "Neptune Avenue",
-      "name": "Neptune Av"
+      "display": "Bay 50th Street",
+      "name": "Bay 50 St",
+      "gtfsStopId": "B23",
+      "latitude": 40.588841,
+      "longitude": -73.983765
     },
     {
       "display": "Coney Island-Stillwell Avenue",
-      "name": "Coney Island-Stillwell Av"
+      "name": "Coney Island-Stillwell Av",
+      "gtfsStopId": "D43",
+      "latitude": 40.577422,
+      "longitude": -73.981233
+    }
+  ],
+  "E": [
+    {
+      "display": "Jamaica Center-Parsons/Archer",
+      "name": "Jamaica Center-Parsons/Archer",
+      "gtfsStopId": "G05",
+      "latitude": 40.702147,
+      "longitude": -73.801109
+    },
+    {
+      "display": "Sutphin Boulevard-Archer Avenue-JFK Airport",
+      "name": "Sutphin Blvd-Archer Av-JFK Airport",
+      "gtfsStopId": "G06",
+      "latitude": 40.700486,
+      "longitude": -73.807969
+    },
+    {
+      "display": "Jamaica-Van Wyck",
+      "name": "Jamaica-Van Wyck",
+      "gtfsStopId": "G07",
+      "latitude": 40.702566,
+      "longitude": -73.816859
+    },
+    {
+      "display": "Kew Gardens-Union Turnpike",
+      "name": "Kew Gardens-Union Tpke",
+      "gtfsStopId": "F06",
+      "latitude": 40.714441,
+      "longitude": -73.831008
+    },
+    {
+      "display": "Forest Hills-71st Avenue",
+      "name": "Forest Hills-71 Av",
+      "gtfsStopId": "G08",
+      "latitude": 40.721691,
+      "longitude": -73.844521
+    },
+    {
+      "display": "Jackson Heights-Roosevelt Avenue",
+      "name": "Jackson Hts-Roosevelt Av",
+      "gtfsStopId": "G14",
+      "latitude": 40.746644,
+      "longitude": -73.891338
+    },
+    {
+      "display": "Queens Plaza",
+      "name": "Queens Plaza",
+      "gtfsStopId": "G21",
+      "latitude": 40.748973,
+      "longitude": -73.937243
+    },
+    {
+      "display": "Court Square-23rd Street",
+      "name": "Court Sq-23 St",
+      "gtfsStopId": "F09",
+      "latitude": 40.747846,
+      "longitude": -73.946
+    },
+    {
+      "display": "Lexington Avenue-53rd Street",
+      "name": "51 St / Lexington Av/53 St",
+      "gtfsStopId": "F11",
+      "latitude": 40.757552,
+      "longitude": -73.969055
+    },
+    {
+      "display": "5th Avenue-53rd Street",
+      "name": "5 Av/53 St",
+      "gtfsStopId": "F12",
+      "latitude": 40.760167,
+      "longitude": -73.975224
+    },
+    {
+      "display": "7th Avenue",
+      "name": "7 Av",
+      "gtfsStopId": "D14",
+      "latitude": 40.762862,
+      "longitude": -73.981637
+    },
+    {
+      "display": "50th Street",
+      "name": "50 St",
+      "gtfsStopId": "A25",
+      "latitude": 40.762456,
+      "longitude": -73.985984
+    },
+    {
+      "display": "42nd Street-Port Authority Bus Terminal",
+      "name": "42 St-Port Authority Bus Terminal",
+      "gtfsStopId": "A27",
+      "latitude": 40.757308,
+      "longitude": -73.989735
+    },
+    {
+      "display": "34th Street-Penn Station",
+      "name": "34 St-Penn Station",
+      "gtfsStopId": "A28",
+      "latitude": 40.752287,
+      "longitude": -73.993391
+    },
+    {
+      "display": "23rd Street",
+      "name": "23 St",
+      "gtfsStopId": "A30",
+      "latitude": 40.745906,
+      "longitude": -73.998041
+    },
+    {
+      "display": "14th Street",
+      "name": "14 St / 8 Av",
+      "gtfsStopId": "A31",
+      "latitude": 40.740893,
+      "longitude": -74.00169
+    },
+    {
+      "display": "West 4th Street-Washington Square",
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "A32",
+      "latitude": 40.732338,
+      "longitude": -74.000495
+    },
+    {
+      "display": "Spring Street",
+      "name": "Spring St",
+      "gtfsStopId": "A33",
+      "latitude": 40.726227,
+      "longitude": -74.003739
+    },
+    {
+      "display": "Canal Street",
+      "name": "Canal St",
+      "gtfsStopId": "A34",
+      "latitude": 40.720824,
+      "longitude": -74.005229
+    },
+    {
+      "display": "World Trade Center",
+      "name": "World Trade Center",
+      "gtfsStopId": "E01",
+      "latitude": 40.712582,
+      "longitude": -74.009781
+    }
+  ],
+  "F": [
+    {
+      "display": "Jamaica-179th Street",
+      "name": "Jamaica-179 St",
+      "gtfsStopId": "F01",
+      "latitude": 40.712646,
+      "longitude": -73.783817
+    },
+    {
+      "display": "169th Street",
+      "name": "169 St",
+      "gtfsStopId": "F02",
+      "latitude": 40.71047,
+      "longitude": -73.793604
+    },
+    {
+      "display": "Parsons Boulevard",
+      "name": "Parsons Blvd",
+      "gtfsStopId": "F03",
+      "latitude": 40.707564,
+      "longitude": -73.803326
+    },
+    {
+      "display": "Sutphin Boulevard",
+      "name": "Sutphin Blvd",
+      "gtfsStopId": "F04",
+      "latitude": 40.70546,
+      "longitude": -73.810708
+    },
+    {
+      "display": "Briarwood",
+      "name": "Briarwood",
+      "gtfsStopId": "F05",
+      "latitude": 40.709179,
+      "longitude": -73.820574
+    },
+    {
+      "display": "Kew Gardens-Union Turnpike",
+      "name": "Kew Gardens-Union Tpke",
+      "gtfsStopId": "F06",
+      "latitude": 40.714441,
+      "longitude": -73.831008
+    },
+    {
+      "display": "75th Avenue",
+      "name": "75 Av",
+      "gtfsStopId": "F07",
+      "latitude": 40.718331,
+      "longitude": -73.837324
+    },
+    {
+      "display": "Forest Hills-71st Avenue",
+      "name": "Forest Hills-71 Av",
+      "gtfsStopId": "G08",
+      "latitude": 40.721691,
+      "longitude": -73.844521
+    },
+    {
+      "display": "Lexington Avenue-63rd Street",
+      "name": "Lexington Av/63 St",
+      "gtfsStopId": "B08",
+      "latitude": 40.764629,
+      "longitude": -73.966113
+    },
+    {
+      "display": "Roosevelt Island",
+      "name": "Roosevelt Island",
+      "gtfsStopId": "B06",
+      "latitude": 40.759145,
+      "longitude": -73.95326
+    },
+    {
+      "display": "Jackson Heights-Roosevelt Avenue",
+      "name": "Roosevelt Av / 74 St-Broadway",
+      "gtfsStopId": "G14",
+      "latitude": 40.746644,
+      "longitude": -73.891338
+    },
+    {
+      "display": "Queens Plaza",
+      "name": "Queens Plaza",
+      "gtfsStopId": "G21",
+      "latitude": 40.748973,
+      "longitude": -73.937243
+    },
+    {
+      "display": "21st Street-Queensbridge",
+      "name": "21 St-Queensbridge",
+      "gtfsStopId": "F09",
+      "latitude": 40.747846,
+      "longitude": -73.946
+    },
+    {
+      "display": "Lexington Avenue-53rd Street",
+      "name": "Lexington Av/53 St",
+      "gtfsStopId": "F11",
+      "latitude": 40.757552,
+      "longitude": -73.969055
+    },
+    {
+      "display": "57th Street",
+      "name": "57 St",
+      "gtfsStopId": "F12",
+      "latitude": 40.760167,
+      "longitude": -73.975224
+    },
+    {
+      "display": "47th-50th Streets-Rockefeller Center",
+      "name": "47-50 Sts-Rockefeller Ctr",
+      "gtfsStopId": "D15",
+      "latitude": 40.758663,
+      "longitude": -73.981329
+    },
+    {
+      "display": "42nd Street-Bryant Park",
+      "name": "42 St-Bryant Pk",
+      "gtfsStopId": "D16",
+      "latitude": 40.754222,
+      "longitude": -73.984569
+    },
+    {
+      "display": "34th Street-Herald Square",
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "D17",
+      "latitude": 40.749719,
+      "longitude": -73.987823
+    },
+    {
+      "display": "23rd Street",
+      "name": "23 St",
+      "gtfsStopId": "D18",
+      "latitude": 40.742878,
+      "longitude": -73.992821
+    },
+    {
+      "display": "14th Street",
+      "name": "14 St / 6 Av",
+      "gtfsStopId": "D19",
+      "latitude": 40.738228,
+      "longitude": -73.996209
+    },
+    {
+      "display": "West 4th Street-Washington Square",
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "D20",
+      "latitude": 40.732338,
+      "longitude": -74.000495
+    },
+    {
+      "display": "Broadway-Lafayette Street",
+      "name": "Bleecker St / Broadway-Lafayette St",
+      "gtfsStopId": "D21",
+      "latitude": 40.725297,
+      "longitude": -73.996204
+    },
+    {
+      "display": "2nd Avenue",
+      "name": "2 Av",
+      "gtfsStopId": "F14",
+      "latitude": 40.723402,
+      "longitude": -73.989938
+    },
+    {
+      "display": "Delancey Street-Essex Street",
+      "name": "Delancey St-Essex St",
+      "gtfsStopId": "F15",
+      "latitude": 40.718611,
+      "longitude": -73.988114
+    },
+    {
+      "display": "East Broadway",
+      "name": "East Broadway",
+      "gtfsStopId": "F16",
+      "latitude": 40.713715,
+      "longitude": -73.990173
+    },
+    {
+      "display": "York Street",
+      "name": "York St",
+      "gtfsStopId": "F18",
+      "latitude": 40.701397,
+      "longitude": -73.986751
+    },
+    {
+      "display": "Jay Street-MetroTech",
+      "name": "Jay St-MetroTech",
+      "gtfsStopId": "A41",
+      "latitude": 40.692338,
+      "longitude": -73.987342
+    },
+    {
+      "display": "Bergen Street",
+      "name": "Bergen St",
+      "gtfsStopId": "F20",
+      "latitude": 40.686145,
+      "longitude": -73.990862
+    },
+    {
+      "display": "Carroll Street",
+      "name": "Carroll St",
+      "gtfsStopId": "F21",
+      "latitude": 40.680303,
+      "longitude": -73.995048
+    },
+    {
+      "display": "Smith-9th Streets",
+      "name": "Smith-9 Sts",
+      "gtfsStopId": "F22",
+      "latitude": 40.67358,
+      "longitude": -73.995959
+    },
+    {
+      "display": "4th Avenue-9th Street",
+      "name": "4 Av-9 St",
+      "gtfsStopId": "F23",
+      "latitude": 40.670272,
+      "longitude": -73.989779
+    },
+    {
+      "display": "7th Avenue",
+      "name": "7 Av",
+      "gtfsStopId": "F24",
+      "latitude": 40.666271,
+      "longitude": -73.980305
+    },
+    {
+      "display": "15th Street-Prospect Park",
+      "name": "15 St-Prospect Park",
+      "gtfsStopId": "F25",
+      "latitude": 40.660365,
+      "longitude": -73.979493
+    },
+    {
+      "display": "Fort Hamilton Parkway",
+      "name": "Fort Hamilton Pkwy",
+      "gtfsStopId": "F26",
+      "latitude": 40.650782,
+      "longitude": -73.975776
+    },
+    {
+      "display": "Church Avenue",
+      "name": "Church Av",
+      "gtfsStopId": "F27",
+      "latitude": 40.644041,
+      "longitude": -73.979678
+    },
+    {
+      "display": "Ditmas Avenue",
+      "name": "Ditmas Av",
+      "gtfsStopId": "F29",
+      "latitude": 40.636119,
+      "longitude": -73.978172
+    },
+    {
+      "display": "18th Avenue",
+      "name": "18 Av",
+      "gtfsStopId": "F30",
+      "latitude": 40.629755,
+      "longitude": -73.976971
+    },
+    {
+      "display": "Avenue I",
+      "name": "Avenue I",
+      "gtfsStopId": "F31",
+      "latitude": 40.625322,
+      "longitude": -73.976127
+    },
+    {
+      "display": "Bay Parkway",
+      "name": "Bay Pkwy",
+      "gtfsStopId": "F32",
+      "latitude": 40.620769,
+      "longitude": -73.975264
+    },
+    {
+      "display": "Avenue N",
+      "name": "Avenue N",
+      "gtfsStopId": "F33",
+      "latitude": 40.61514,
+      "longitude": -73.974197
+    },
+    {
+      "display": "Avenue P",
+      "name": "Avenue P",
+      "gtfsStopId": "F34",
+      "latitude": 40.608944,
+      "longitude": -73.973022
+    },
+    {
+      "display": "Kings Highway",
+      "name": "Kings Hwy",
+      "gtfsStopId": "F35",
+      "latitude": 40.603217,
+      "longitude": -73.972361
+    },
+    {
+      "display": "Avenue U",
+      "name": "Avenue U",
+      "gtfsStopId": "F36",
+      "latitude": 40.596063,
+      "longitude": -73.973357
+    },
+    {
+      "display": "Avenue X",
+      "name": "Avenue X",
+      "gtfsStopId": "F38",
+      "latitude": 40.58962,
+      "longitude": -73.97425
+    },
+    {
+      "display": "Neptune Avenue",
+      "name": "Neptune Av",
+      "gtfsStopId": "F39",
+      "latitude": 40.581011,
+      "longitude": -73.974574
+    },
+    {
+      "display": "West 8th Street-NY Aquarium",
+      "name": "W 8 St-NY Aquarium",
+      "gtfsStopId": "D42",
+      "latitude": 40.576127,
+      "longitude": -73.975939
+    },
+    {
+      "display": "Coney Island-Stillwell Avenue",
+      "name": "Coney Island-Stillwell Av",
+      "gtfsStopId": "D43",
+      "latitude": 40.577422,
+      "longitude": -73.981233
     }
   ],
   "G": [
     {
       "display": "Court Square",
-      "name": "Court Sq-23 St"
+      "name": "Court Sq-23 St",
+      "gtfsStopId": "G22",
+      "latitude": 40.746554,
+      "longitude": -73.943832
     },
     {
       "display": "21st Street",
-      "name": "21 St"
+      "name": "21 St",
+      "gtfsStopId": "G24",
+      "latitude": 40.744065,
+      "longitude": -73.949724
     },
     {
       "display": "Greenpoint Avenue",
-      "name": "Greenpoint Av"
+      "name": "Greenpoint Av",
+      "gtfsStopId": "G26",
+      "latitude": 40.731352,
+      "longitude": -73.954449
     },
     {
       "display": "Nassau Avenue",
-      "name": "Nassau Av"
+      "name": "Nassau Av",
+      "gtfsStopId": "G28",
+      "latitude": 40.724635,
+      "longitude": -73.951277
     },
     {
-      "display": "Metropolitan Avenue-Lorimer Street",
-      "name": "Metropolitan Av / Lorimer St"
+      "display": "Metropolitan Avenue",
+      "name": "Metropolitan Av",
+      "gtfsStopId": "G29",
+      "latitude": 40.712792,
+      "longitude": -73.951418
     },
     {
       "display": "Broadway",
-      "name": "Broadway"
+      "name": "Broadway",
+      "gtfsStopId": "G30",
+      "latitude": 40.706092,
+      "longitude": -73.950308
     },
     {
       "display": "Flushing Avenue",
-      "name": "Flushing Av"
+      "name": "Flushing Av",
+      "gtfsStopId": "G31",
+      "latitude": 40.700377,
+      "longitude": -73.950234
     },
     {
       "display": "Myrtle-Willoughby Avenues",
-      "name": "Myrtle-Willoughby Avs"
+      "name": "Myrtle-Willoughby Avs",
+      "gtfsStopId": "G32",
+      "latitude": 40.694568,
+      "longitude": -73.949046
     },
     {
       "display": "Bedford-Nostrand Avenues",
-      "name": "Bedford-Nostrand Avs"
+      "name": "Bedford-Nostrand Avs",
+      "gtfsStopId": "G33",
+      "latitude": 40.689627,
+      "longitude": -73.953522
     },
     {
       "display": "Classon Avenue",
-      "name": "Classon Av"
+      "name": "Classon Av",
+      "gtfsStopId": "G34",
+      "latitude": 40.688873,
+      "longitude": -73.96007
     },
     {
       "display": "Clinton-Washington Avenues",
-      "name": "Clinton-Washington Avs"
+      "name": "Clinton-Washington Avs",
+      "gtfsStopId": "G35",
+      "latitude": 40.688089,
+      "longitude": -73.966839
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "G36",
+      "latitude": 40.687119,
+      "longitude": -73.975375
     },
     {
       "display": "Hoyt-Schermerhorn Streets",
-      "name": "Hoyt-Schermerhorn Sts"
+      "name": "Hoyt-Schermerhorn Sts",
+      "gtfsStopId": "A42",
+      "latitude": 40.688484,
+      "longitude": -73.985001
     },
     {
       "display": "Bergen Street",
-      "name": "Bergen St"
+      "name": "Bergen St",
+      "gtfsStopId": "F20",
+      "latitude": 40.686145,
+      "longitude": -73.990862
     },
     {
       "display": "Carroll Street",
-      "name": "Carroll St"
+      "name": "Carroll St",
+      "gtfsStopId": "F21",
+      "latitude": 40.680303,
+      "longitude": -73.995048
     },
     {
       "display": "Smith-9th Streets",
-      "name": "Smith-9 Sts"
+      "name": "Smith-9 Sts",
+      "gtfsStopId": "F22",
+      "latitude": 40.67358,
+      "longitude": -73.995959
     },
     {
       "display": "4th Avenue-9th Street",
-      "name": "4 Av-9 St"
+      "name": "4 Av-9 St",
+      "gtfsStopId": "F23",
+      "latitude": 40.670272,
+      "longitude": -73.989779
     },
     {
       "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "7 Av",
+      "gtfsStopId": "F24",
+      "latitude": 40.666271,
+      "longitude": -73.980305
     },
     {
       "display": "15th Street-Prospect Park",
-      "name": "15 St-Prospect Park"
+      "name": "15 St-Prospect Park",
+      "gtfsStopId": "F25",
+      "latitude": 40.660365,
+      "longitude": -73.979493
     },
     {
       "display": "Fort Hamilton Parkway",
-      "name": "Fort Hamilton Pkwy"
+      "name": "Fort Hamilton Pkwy",
+      "gtfsStopId": "F26",
+      "latitude": 40.650782,
+      "longitude": -73.975776
     },
     {
       "display": "Church Avenue",
-      "name": "Church Av"
+      "name": "Church Av",
+      "gtfsStopId": "F27",
+      "latitude": 40.644041,
+      "longitude": -73.979678
     }
   ],
   "J": [
     {
       "display": "Jamaica Center-Parsons/Archer",
-      "name": "Jamaica Center-Parsons/Archer"
+      "name": "Jamaica Center-Parsons/Archer",
+      "gtfsStopId": "G05",
+      "latitude": 40.702147,
+      "longitude": -73.801109
     },
     {
       "display": "Sutphin Boulevard-Archer Avenue-JFK Airport",
-      "name": "Sutphin Blvd-Archer Av-JFK Airport"
+      "name": "Sutphin Blvd-Archer Av-JFK Airport",
+      "gtfsStopId": "G06",
+      "latitude": 40.700486,
+      "longitude": -73.807969
     },
     {
       "display": "121st Street",
-      "name": "121 St"
+      "name": "121 St",
+      "gtfsStopId": "J12",
+      "latitude": 40.700492,
+      "longitude": -73.828294
     },
     {
       "display": "111th Street",
-      "name": "111 St"
+      "name": "111 St",
+      "gtfsStopId": "J13",
+      "latitude": 40.697418,
+      "longitude": -73.836345
     },
     {
       "display": "104th Street",
-      "name": "104 St"
+      "name": "104 St",
+      "gtfsStopId": "J14",
+      "latitude": 40.695178,
+      "longitude": -73.84433
     },
     {
       "display": "Woodhaven Boulevard",
-      "name": "Woodhaven Blvd"
+      "name": "Woodhaven Blvd",
+      "gtfsStopId": "J15",
+      "latitude": 40.693879,
+      "longitude": -73.851576
     },
     {
       "display": "85th Street-Forest Parkway",
-      "name": "85 St-Forest Pkwy"
+      "name": "85 St-Forest Pkwy",
+      "gtfsStopId": "J16",
+      "latitude": 40.692435,
+      "longitude": -73.86001
     },
     {
       "display": "75th Street-Elderts Lane",
-      "name": "75 St-Elderts Ln"
+      "name": "75 St-Elderts Ln",
+      "gtfsStopId": "J17",
+      "latitude": 40.691324,
+      "longitude": -73.867139
     },
     {
       "display": "Cypress Hills",
-      "name": "Cypress Hills"
+      "name": "Cypress Hills",
+      "gtfsStopId": "J19",
+      "latitude": 40.689941,
+      "longitude": -73.87255
     },
     {
       "display": "Crescent Street",
-      "name": "Crescent St"
+      "name": "Crescent St",
+      "gtfsStopId": "J20",
+      "latitude": 40.683194,
+      "longitude": -73.873785
     },
     {
       "display": "Norwood Avenue",
-      "name": "Norwood Av"
+      "name": "Norwood Av",
+      "gtfsStopId": "J21",
+      "latitude": 40.68141,
+      "longitude": -73.880039
     },
     {
       "display": "Cleveland Street",
-      "name": "Cleveland St"
+      "name": "Cleveland St",
+      "gtfsStopId": "J22",
+      "latitude": 40.679947,
+      "longitude": -73.884639
     },
     {
       "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
+      "name": "Van Siclen Av",
+      "gtfsStopId": "J23",
+      "latitude": 40.678024,
+      "longitude": -73.891688
     },
     {
       "display": "Alabama Avenue",
-      "name": "Alabama Av"
+      "name": "Alabama Av",
+      "gtfsStopId": "J24",
+      "latitude": 40.676992,
+      "longitude": -73.898654
     },
     {
       "display": "Broadway Junction",
-      "name": "Broadway Junction"
+      "name": "Broadway Junction",
+      "gtfsStopId": "J27",
+      "latitude": 40.679498,
+      "longitude": -73.904512
     },
     {
       "display": "Chauncey Street",
-      "name": "Chauncey St"
+      "name": "Chauncey St",
+      "gtfsStopId": "J28",
+      "latitude": 40.682893,
+      "longitude": -73.910456
     },
     {
       "display": "Halsey Street",
-      "name": "Halsey St"
+      "name": "Halsey St",
+      "gtfsStopId": "J29",
+      "latitude": 40.68637,
+      "longitude": -73.916559
     },
     {
       "display": "Gates Avenue",
-      "name": "Gates Av"
+      "name": "Gates Av",
+      "gtfsStopId": "J30",
+      "latitude": 40.68963,
+      "longitude": -73.92227
     },
     {
       "display": "Kosciuszko Street",
-      "name": "Kosciuszko St"
+      "name": "Kosciuszko St",
+      "gtfsStopId": "J31",
+      "latitude": 40.693342,
+      "longitude": -73.928814
     },
     {
       "display": "Myrtle Avenue",
-      "name": "Myrtle Av"
+      "name": "Myrtle Av",
+      "gtfsStopId": "M11",
+      "latitude": 40.697207,
+      "longitude": -73.935657
     },
     {
       "display": "Flushing Avenue",
-      "name": "Flushing Av"
+      "name": "Flushing Av",
+      "gtfsStopId": "M12",
+      "latitude": 40.70026,
+      "longitude": -73.941126
     },
     {
       "display": "Lorimer Street",
-      "name": "Lorimer St"
+      "name": "Lorimer St",
+      "gtfsStopId": "M13",
+      "latitude": 40.703869,
+      "longitude": -73.947408
     },
     {
       "display": "Hewes Street",
-      "name": "Hewes St"
+      "name": "Hewes St",
+      "gtfsStopId": "M14",
+      "latitude": 40.70687,
+      "longitude": -73.953431
     },
     {
       "display": "Marcy Avenue",
-      "name": "Marcy Av"
+      "name": "Marcy Av",
+      "gtfsStopId": "M16",
+      "latitude": 40.708359,
+      "longitude": -73.957757
     },
     {
       "display": "Delancey Street-Essex Street",
-      "name": "Delancey St-Essex St"
+      "name": "Delancey St-Essex St",
+      "gtfsStopId": "M18",
+      "latitude": 40.718315,
+      "longitude": -73.987437
     },
     {
       "display": "Bowery",
-      "name": "Bowery"
+      "name": "Bowery",
+      "gtfsStopId": "M19",
+      "latitude": 40.72028,
+      "longitude": -73.993915
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "M20",
+      "latitude": 40.718092,
+      "longitude": -73.999892
     },
     {
       "display": "Chambers Street",
-      "name": "Brooklyn Bridge-City Hall / Chambers St"
+      "name": "Brooklyn Bridge-City Hall / Chambers St",
+      "gtfsStopId": "M21",
+      "latitude": 40.713243,
+      "longitude": -74.003401
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "M22",
+      "latitude": 40.710374,
+      "longitude": -74.007582
     },
     {
       "display": "Broad Street",
-      "name": "Broad St"
+      "name": "Broad St",
+      "gtfsStopId": "M23",
+      "latitude": 40.706476,
+      "longitude": -74.011056
     }
   ],
   "L": [
     {
       "display": "8th Avenue",
-      "name": "14 St / 8 Av"
+      "name": "14 St / 8 Av",
+      "gtfsStopId": "L01",
+      "latitude": 40.740322,
+      "longitude": -74.002906
     },
     {
       "display": "6th Avenue",
-      "name": "14 St / 6 Av"
+      "name": "14 St / 6 Av",
+      "gtfsStopId": "L02",
+      "latitude": 40.737826,
+      "longitude": -73.996209
     },
     {
       "display": "Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "L03",
+      "latitude": 40.735736,
+      "longitude": -73.990568
     },
     {
       "display": "3rd Avenue",
-      "name": "3 Av"
+      "name": "3 Av",
+      "gtfsStopId": "L05",
+      "latitude": 40.732849,
+      "longitude": -73.986122
     },
     {
       "display": "1st Avenue",
-      "name": "1 Av"
+      "name": "1 Av",
+      "gtfsStopId": "L06",
+      "latitude": 40.730953,
+      "longitude": -73.981628
     },
     {
       "display": "Bedford Avenue",
-      "name": "Bedford Av"
+      "name": "Bedford Av",
+      "gtfsStopId": "L08",
+      "latitude": 40.717304,
+      "longitude": -73.956872
     },
     {
       "display": "Lorimer Street",
-      "name": "Metropolitan Av / Lorimer St"
+      "name": "Lorimer St",
+      "gtfsStopId": "L10",
+      "latitude": 40.714063,
+      "longitude": -73.950275
     },
     {
       "display": "Graham Avenue",
-      "name": "Graham Av"
+      "name": "Graham Av",
+      "gtfsStopId": "L11",
+      "latitude": 40.714565,
+      "longitude": -73.944053
     },
     {
       "display": "Grand Street",
-      "name": "Grand St"
+      "name": "Grand St",
+      "gtfsStopId": "L12",
+      "latitude": 40.711926,
+      "longitude": -73.94067
     },
     {
       "display": "Montrose Avenue",
-      "name": "Montrose Av"
+      "name": "Montrose Av",
+      "gtfsStopId": "L13",
+      "latitude": 40.707739,
+      "longitude": -73.93985
     },
     {
       "display": "Morgan Avenue",
-      "name": "Morgan Av"
+      "name": "Morgan Av",
+      "gtfsStopId": "L14",
+      "latitude": 40.706152,
+      "longitude": -73.933147
     },
     {
       "display": "Jefferson Street",
-      "name": "Jefferson St"
+      "name": "Jefferson St",
+      "gtfsStopId": "L15",
+      "latitude": 40.706607,
+      "longitude": -73.922913
     },
     {
       "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
+      "name": "DeKalb Av",
+      "gtfsStopId": "L16",
+      "latitude": 40.703811,
+      "longitude": -73.918425
     },
     {
       "display": "Myrtle-Wyckoff Avenues",
-      "name": "Myrtle-Wyckoff Avs"
+      "name": "Myrtle-Wyckoff Avs",
+      "gtfsStopId": "L17",
+      "latitude": 40.69943,
+      "longitude": -73.912385
     },
     {
       "display": "Halsey Street",
-      "name": "Halsey St"
+      "name": "Halsey St",
+      "gtfsStopId": "L19",
+      "latitude": 40.695602,
+      "longitude": -73.904084
     },
     {
       "display": "Wilson Avenue",
-      "name": "Wilson Av"
+      "name": "Wilson Av",
+      "gtfsStopId": "L20",
+      "latitude": 40.688764,
+      "longitude": -73.904046
     },
     {
       "display": "Bushwick Avenue-Aberdeen Street",
-      "name": "Bushwick Av-Aberdeen St"
+      "name": "Bushwick Av-Aberdeen St",
+      "gtfsStopId": "L21",
+      "latitude": 40.682829,
+      "longitude": -73.905249
     },
     {
       "display": "Broadway Junction",
-      "name": "Broadway Junction"
+      "name": "Broadway Junction",
+      "gtfsStopId": "L22",
+      "latitude": 40.678856,
+      "longitude": -73.90324
     },
     {
       "display": "Atlantic Avenue",
-      "name": "Atlantic Av"
+      "name": "Atlantic Av",
+      "gtfsStopId": "L24",
+      "latitude": 40.675345,
+      "longitude": -73.903097
     },
     {
       "display": "Sutter Avenue",
-      "name": "Sutter Av"
+      "name": "Sutter Av",
+      "gtfsStopId": "L25",
+      "latitude": 40.669367,
+      "longitude": -73.901975
     },
     {
       "display": "Livonia Avenue",
-      "name": "Junius St / Livonia Av"
+      "name": "Livonia Av",
+      "gtfsStopId": "L26",
+      "latitude": 40.664038,
+      "longitude": -73.900571
     },
     {
       "display": "New Lots Avenue",
-      "name": "New Lots Av"
+      "name": "New Lots Av",
+      "gtfsStopId": "L27",
+      "latitude": 40.658733,
+      "longitude": -73.899232
     },
     {
       "display": "East 105th Street",
-      "name": "East 105 St"
+      "name": "East 105 St",
+      "gtfsStopId": "L28",
+      "latitude": 40.650573,
+      "longitude": -73.899485
     },
     {
       "display": "Canarsie-Rockaway Parkway",
-      "name": "Canarsie-Rockaway Pkwy"
+      "name": "Canarsie-Rockaway Pkwy",
+      "gtfsStopId": "L29",
+      "latitude": 40.646654,
+      "longitude": -73.90185
     }
   ],
   "M": [
     {
       "display": "Forest Hills-71st Avenue",
-      "name": "Forest Hills-71 Av"
+      "name": "Forest Hills-71 Av",
+      "gtfsStopId": "G08",
+      "latitude": 40.721691,
+      "longitude": -73.844521
     },
     {
       "display": "67th Avenue",
-      "name": "67 Av"
+      "name": "67 Av",
+      "gtfsStopId": "G09",
+      "latitude": 40.726523,
+      "longitude": -73.852719
     },
     {
       "display": "63rd Drive-Rego Park",
-      "name": "63 Dr-Rego Park"
+      "name": "63 Dr-Rego Park",
+      "gtfsStopId": "G10",
+      "latitude": 40.729846,
+      "longitude": -73.861604
     },
     {
       "display": "Woodhaven Boulevard",
-      "name": "Woodhaven Blvd"
+      "name": "Woodhaven Blvd",
+      "gtfsStopId": "G11",
+      "latitude": 40.733106,
+      "longitude": -73.869229
     },
     {
       "display": "Grand Avenue-Newtown",
-      "name": "Grand Av-Newtown"
+      "name": "Grand Av-Newtown",
+      "gtfsStopId": "G12",
+      "latitude": 40.737015,
+      "longitude": -73.877223
     },
     {
       "display": "Elmhurst Avenue",
-      "name": "Elmhurst Av"
+      "name": "Elmhurst Av",
+      "gtfsStopId": "G13",
+      "latitude": 40.742454,
+      "longitude": -73.882017
     },
     {
       "display": "Jackson Heights-Roosevelt Avenue",
-      "name": "Jackson Heights-Roosevelt Av"
+      "name": "Jackson Heights-Roosevelt Av",
+      "gtfsStopId": "G14",
+      "latitude": 40.746644,
+      "longitude": -73.891338
     },
     {
       "display": "65th Street",
-      "name": "65 St"
+      "name": "65 St",
+      "gtfsStopId": "G15",
+      "latitude": 40.749669,
+      "longitude": -73.898453
     },
     {
       "display": "Northern Boulevard",
-      "name": "Northern Blvd"
+      "name": "Northern Blvd",
+      "gtfsStopId": "G16",
+      "latitude": 40.752885,
+      "longitude": -73.906006
     },
     {
       "display": "46th Street",
-      "name": "46 St"
+      "name": "46 St",
+      "gtfsStopId": "G18",
+      "latitude": 40.756312,
+      "longitude": -73.913333
     },
     {
       "display": "Steinway Street",
-      "name": "Steinway St"
+      "name": "Steinway St",
+      "gtfsStopId": "G19",
+      "latitude": 40.756879,
+      "longitude": -73.92074
     },
     {
-      "display": "Queens Plaza",
-      "name": "Queens Plaza"
+      "display": "36th Street",
+      "name": "36 St",
+      "gtfsStopId": "G20",
+      "latitude": 40.752039,
+      "longitude": -73.928781
     },
     {
-      "display": "Court Square-23rd Street",
-      "name": "Court Sq-23 St"
+      "display": "21st Street-Queensbridge",
+      "name": "21 St-Queensbridge",
+      "gtfsStopId": "B04",
+      "latitude": 40.754203,
+      "longitude": -73.942836
+    },
+    {
+      "display": "Roosevelt Island",
+      "name": "Roosevelt Island",
+      "gtfsStopId": "B06",
+      "latitude": 40.759145,
+      "longitude": -73.95326
     },
     {
       "display": "Lexington Avenue-53rd Street",
-      "name": "Lexington Av-53 St"
+      "name": "Lexington Av-53 St",
+      "gtfsStopId": "B08",
+      "latitude": 40.764629,
+      "longitude": -73.966113
     },
     {
       "display": "5th Avenue-53rd Street",
-      "name": "5 Av/53 St"
+      "name": "5 Av/53 St",
+      "gtfsStopId": "B10",
+      "latitude": 40.763972,
+      "longitude": -73.97745
     },
     {
       "display": "47th-50th Streets-Rockefeller Center",
-      "name": "47-50 Sts-Rockefeller Ctr"
+      "name": "47-50 Sts-Rockefeller Ctr",
+      "gtfsStopId": "D15",
+      "latitude": 40.758663,
+      "longitude": -73.981329
     },
     {
       "display": "42nd Street-Bryant Park",
-      "name": "42 St-Bryant Pk"
+      "name": "42 St-Bryant Pk",
+      "gtfsStopId": "D16",
+      "latitude": 40.754222,
+      "longitude": -73.984569
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "D17",
+      "latitude": 40.749719,
+      "longitude": -73.987823
+    },
+    {
+      "display": "23rd Street",
+      "name": "23 St",
+      "gtfsStopId": "D18",
+      "latitude": 40.742878,
+      "longitude": -73.992821
+    },
+    {
+      "display": "14th Street",
+      "name": "14 St",
+      "gtfsStopId": "D19",
+      "latitude": 40.738228,
+      "longitude": -73.996209
     },
     {
       "display": "West 4th Street-Washington Square",
-      "name": "W 4 St-Wash Sq"
+      "name": "W 4 St-Wash Sq",
+      "gtfsStopId": "D20",
+      "latitude": 40.732338,
+      "longitude": -74.000495
     },
     {
       "display": "Broadway-Lafayette Street",
-      "name": "Bleecker St / Broadway-Lafayette St"
+      "name": "Bleecker St / Broadway-Lafayette St",
+      "gtfsStopId": "D21",
+      "latitude": 40.725297,
+      "longitude": -73.996204
     },
     {
-      "display": "Essex Street",
-      "name": "Essex St"
+      "display": "Delancey St-Essex St",
+      "name": "Delancey St-Essex St",
+      "gtfsStopId": "M18",
+      "latitude": 40.718315,
+      "longitude": -73.987437
     },
     {
       "display": "Marcy Avenue",
-      "name": "Marcy Av"
+      "name": "Marcy Av",
+      "gtfsStopId": "M16",
+      "latitude": 40.708359,
+      "longitude": -73.957757
     },
     {
       "display": "Hewes Street",
-      "name": "Hewes St"
+      "name": "Hewes St",
+      "gtfsStopId": "M14",
+      "latitude": 40.70687,
+      "longitude": -73.953431
     },
     {
       "display": "Lorimer Street",
-      "name": "Lorimer St"
+      "name": "Lorimer St",
+      "gtfsStopId": "M13",
+      "latitude": 40.703869,
+      "longitude": -73.947408
     },
     {
       "display": "Flushing Avenue",
-      "name": "Flushing Av"
+      "name": "Flushing Av",
+      "gtfsStopId": "M12",
+      "latitude": 40.70026,
+      "longitude": -73.941126
     },
     {
       "display": "Myrtle Avenue",
-      "name": "Myrtle Av"
+      "name": "Myrtle Av",
+      "gtfsStopId": "M11",
+      "latitude": 40.697207,
+      "longitude": -73.935657
     },
     {
       "display": "Central Avenue",
-      "name": "Central Av"
+      "name": "Central Av",
+      "gtfsStopId": "M10",
+      "latitude": 40.697857,
+      "longitude": -73.927397
     },
     {
       "display": "Knickerbocker Avenue",
-      "name": "Knickerbocker Av"
+      "name": "Knickerbocker Av",
+      "gtfsStopId": "M09",
+      "latitude": 40.698664,
+      "longitude": -73.919711
     },
     {
       "display": "Myrtle-Wyckoff Avenues",
-      "name": "Myrtle-Wyckoff Avs"
+      "name": "Myrtle-Wyckoff Avs",
+      "gtfsStopId": "M08",
+      "latitude": 40.69943,
+      "longitude": -73.912385
     },
     {
       "display": "Seneca Avenue",
-      "name": "Seneca Av"
+      "name": "Seneca Av",
+      "gtfsStopId": "M06",
+      "latitude": 40.702762,
+      "longitude": -73.90774
     },
     {
       "display": "Forest Avenue",
-      "name": "Forest Av"
+      "name": "Forest Av",
+      "gtfsStopId": "M05",
+      "latitude": 40.704423,
+      "longitude": -73.903077
     },
     {
       "display": "Fresh Pond Road",
-      "name": "Fresh Pond Rd"
+      "name": "Fresh Pond Rd",
+      "gtfsStopId": "M04",
+      "latitude": 40.706186,
+      "longitude": -73.895877
     },
     {
       "display": "Middle Village-Metropolitan Avenue",
-      "name": "Middle Village-Metropolitan Av"
+      "name": "Middle Village-Metropolitan Av",
+      "gtfsStopId": "M01",
+      "latitude": 40.711396,
+      "longitude": -73.889601
     }
   ],
   "N": [
     {
       "display": "Astoria-Ditmars Boulevard",
-      "name": "Astoria-Ditmars Blvd"
+      "name": "Astoria-Ditmars Blvd",
+      "gtfsStopId": "R01",
+      "latitude": 40.775036,
+      "longitude": -73.912034
     },
     {
       "display": "Astoria Boulevard",
-      "name": "Astoria Blvd"
+      "name": "Astoria Blvd",
+      "gtfsStopId": "R03",
+      "latitude": 40.770258,
+      "longitude": -73.917843
     },
     {
       "display": "30th Avenue",
-      "name": "30 Av"
+      "name": "30 Av",
+      "gtfsStopId": "R04",
+      "latitude": 40.766779,
+      "longitude": -73.921479
     },
     {
       "display": "Broadway",
-      "name": "Broadway"
+      "name": "Broadway",
+      "gtfsStopId": "R05",
+      "latitude": 40.76182,
+      "longitude": -73.925508
     },
     {
       "display": "36th Avenue",
-      "name": "36 Av"
+      "name": "36 Av",
+      "gtfsStopId": "R06",
+      "latitude": 40.756804,
+      "longitude": -73.929575
     },
     {
       "display": "39th Avenue-Dutch Kills",
-      "name": "39 Av-Dutch Kills"
+      "name": "39 Av-Dutch Kills",
+      "gtfsStopId": "R08",
+      "latitude": 40.752882,
+      "longitude": -73.932755
     },
     {
       "display": "Queensboro Plaza",
-      "name": "Queensboro Plaza"
+      "name": "Queensboro Plaza",
+      "gtfsStopId": "R09",
+      "latitude": 40.750582,
+      "longitude": -73.940202
     },
     {
       "display": "Lexington Avenue-59th Street",
-      "name": "Lexington Av/59 St"
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "R11",
+      "latitude": 40.76266,
+      "longitude": -73.967258
     },
     {
       "display": "5th Avenue-59th Street",
-      "name": "5 Av/59 St"
+      "name": "5 Av/59 St",
+      "gtfsStopId": "R13",
+      "latitude": 40.764811,
+      "longitude": -73.973347
     },
     {
       "display": "57th Street-7th Avenue",
-      "name": "57 St-7 Av"
+      "name": "57 St-7 Av",
+      "gtfsStopId": "R14",
+      "latitude": 40.764664,
+      "longitude": -73.980658
     },
     {
       "display": "49th Street",
-      "name": "49 St"
+      "name": "49 St",
+      "gtfsStopId": "R15",
+      "latitude": 40.759901,
+      "longitude": -73.984139
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "R16",
+      "latitude": 40.754672,
+      "longitude": -73.986754
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
-    },
-    {
-      "display": "28th Street",
-      "name": "28 St"
-    },
-    {
-      "display": "23rd Street",
-      "name": "23 St"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "R17",
+      "latitude": 40.749567,
+      "longitude": -73.98795
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "R20",
+      "latitude": 40.735736,
+      "longitude": -73.990568
     },
     {
       "display": "8th Street-NYU",
-      "name": "8 St-NYU"
+      "name": "8 St-NYU",
+      "gtfsStopId": "R21",
+      "latitude": 40.730328,
+      "longitude": -73.992629
     },
     {
       "display": "Prince Street",
-      "name": "Prince St"
+      "name": "Prince St",
+      "gtfsStopId": "R22",
+      "latitude": 40.724329,
+      "longitude": -73.997702
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
-    },
-    {
-      "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
+      "name": "Canal St",
+      "gtfsStopId": "Q01",
+      "latitude": 40.718383,
+      "longitude": -74.00046
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "R31",
+      "latitude": 40.683666,
+      "longitude": -73.97881
     },
     {
       "display": "36th Street",
-      "name": "36 St"
+      "name": "36 St",
+      "gtfsStopId": "R36",
+      "latitude": 40.655144,
+      "longitude": -74.003549
     },
     {
       "display": "59th Street",
-      "name": "59 St"
+      "name": "59 St",
+      "gtfsStopId": "R41",
+      "latitude": 40.641362,
+      "longitude": -74.017881
     },
     {
       "display": "8th Avenue",
-      "name": "8 Av"
+      "name": "8 Av",
+      "gtfsStopId": "N02",
+      "latitude": 40.635064,
+      "longitude": -74.011719
     },
     {
       "display": "Fort Hamilton Parkway",
-      "name": "Fort Hamilton Pkwy"
+      "name": "Fort Hamilton Pkwy",
+      "gtfsStopId": "N03",
+      "latitude": 40.631386,
+      "longitude": -74.005351
     },
     {
       "display": "New Utrecht Avenue",
-      "name": "62 St / New Utrecht Av"
+      "name": "62 St / New Utrecht Av",
+      "gtfsStopId": "N04",
+      "latitude": 40.624842,
+      "longitude": -73.996353
     },
     {
       "display": "18th Avenue",
-      "name": "18 Av"
+      "name": "18 Av",
+      "gtfsStopId": "N05",
+      "latitude": 40.620671,
+      "longitude": -73.990414
     },
     {
       "display": "20th Avenue",
-      "name": "20 Av"
+      "name": "20 Av",
+      "gtfsStopId": "N06",
+      "latitude": 40.61741,
+      "longitude": -73.985026
     },
     {
       "display": "Bay Parkway",
-      "name": "Bay Pkwy"
+      "name": "Bay Pkwy",
+      "gtfsStopId": "N07",
+      "latitude": 40.611815,
+      "longitude": -73.981848
     },
     {
       "display": "Kings Highway",
-      "name": "Kings Hwy"
+      "name": "Kings Hwy",
+      "gtfsStopId": "N08",
+      "latitude": 40.603923,
+      "longitude": -73.980353
     },
     {
       "display": "Avenue U",
-      "name": "Avenue U"
+      "name": "Avenue U",
+      "gtfsStopId": "N09",
+      "latitude": 40.597473,
+      "longitude": -73.979137
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "N10",
+      "latitude": 40.592721,
+      "longitude": -73.97823
     },
     {
       "display": "Coney Island-Stillwell Avenue",
-      "name": "Coney Island-Stillwell Av"
+      "name": "Coney Island-Stillwell Av",
+      "gtfsStopId": "D43",
+      "latitude": 40.577422,
+      "longitude": -73.981233
     }
   ],
   "Q": [
     {
       "display": "96th Street",
-      "name": "96 St"
+      "name": "96 St",
+      "gtfsStopId": "Q05",
+      "latitude": 40.784318,
+      "longitude": -73.947152
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "Q04",
+      "latitude": 40.777891,
+      "longitude": -73.951787
     },
     {
       "display": "72nd Street",
-      "name": "72 St"
+      "name": "72 St",
+      "gtfsStopId": "Q03",
+      "latitude": 40.768799,
+      "longitude": -73.958424
     },
     {
       "display": "Lexington Avenue-63rd Street",
-      "name": "Lexington Av/63 St"
+      "name": "Lexington Av/63 St",
+      "gtfsStopId": "B08",
+      "latitude": 40.764629,
+      "longitude": -73.966113
     },
     {
       "display": "57th Street-7th Avenue",
-      "name": "57 St-7 Av"
+      "name": "57 St-7 Av",
+      "gtfsStopId": "R14",
+      "latitude": 40.764664,
+      "longitude": -73.980658
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "R16",
+      "latitude": 40.754672,
+      "longitude": -73.986754
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "R17",
+      "latitude": 40.749567,
+      "longitude": -73.98795
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "R20",
+      "latitude": 40.735736,
+      "longitude": -73.990568
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "Q01",
+      "latitude": 40.718383,
+      "longitude": -74.00046
     },
     {
       "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
+      "name": "DeKalb Av",
+      "gtfsStopId": "R30",
+      "latitude": 40.690635,
+      "longitude": -73.981824
     },
     {
       "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "D24",
+      "latitude": 40.68446,
+      "longitude": -73.97689
     },
     {
       "display": "7th Avenue",
-      "name": "7 Av"
+      "name": "7 Av",
+      "gtfsStopId": "D25",
+      "latitude": 40.67705,
+      "longitude": -73.972367
     },
     {
       "display": "Prospect Park",
-      "name": "Prospect Park"
+      "name": "Prospect Park",
+      "gtfsStopId": "D26",
+      "latitude": 40.661614,
+      "longitude": -73.962246
     },
     {
       "display": "Parkside Avenue",
-      "name": "Parkside Av"
+      "name": "Parkside Av",
+      "gtfsStopId": "D27",
+      "latitude": 40.655292,
+      "longitude": -73.961495
     },
     {
       "display": "Church Avenue",
-      "name": "Church Av"
+      "name": "Church Av",
+      "gtfsStopId": "D28",
+      "latitude": 40.650527,
+      "longitude": -73.962982
     },
     {
       "display": "Beverley Road",
-      "name": "Beverley Rd"
+      "name": "Beverley Rd",
+      "gtfsStopId": "D29",
+      "latitude": 40.644031,
+      "longitude": -73.964492
     },
     {
       "display": "Cortelyou Road",
-      "name": "Cortelyou Rd"
+      "name": "Cortelyou Rd",
+      "gtfsStopId": "D30",
+      "latitude": 40.640927,
+      "longitude": -73.963891
     },
     {
       "display": "Newkirk Plaza",
-      "name": "Newkirk Plaza"
+      "name": "Newkirk Plaza",
+      "gtfsStopId": "D31",
+      "latitude": 40.635082,
+      "longitude": -73.962793
     },
     {
       "display": "Avenue H",
-      "name": "Avenue H"
+      "name": "Avenue H",
+      "gtfsStopId": "D32",
+      "latitude": 40.62927,
+      "longitude": -73.961639
     },
     {
       "display": "Avenue J",
-      "name": "Avenue J"
+      "name": "Avenue J",
+      "gtfsStopId": "D33",
+      "latitude": 40.625039,
+      "longitude": -73.960803
     },
     {
       "display": "Avenue M",
-      "name": "Avenue M"
+      "name": "Avenue M",
+      "gtfsStopId": "D34",
+      "latitude": 40.617618,
+      "longitude": -73.959399
     },
     {
       "display": "Kings Highway",
-      "name": "Kings Hwy"
+      "name": "Kings Hwy",
+      "gtfsStopId": "D35",
+      "latitude": 40.60867,
+      "longitude": -73.957734
     },
     {
       "display": "Avenue U",
-      "name": "Avenue U"
+      "name": "Avenue U",
+      "gtfsStopId": "D37",
+      "latitude": 40.5993,
+      "longitude": -73.955929
     },
     {
       "display": "Neck Road",
-      "name": "Neck Rd"
+      "name": "Neck Rd",
+      "gtfsStopId": "D38",
+      "latitude": 40.595246,
+      "longitude": -73.955161
     },
     {
       "display": "Sheepshead Bay",
-      "name": "Sheepshead Bay"
+      "name": "Sheepshead Bay",
+      "gtfsStopId": "D39",
+      "latitude": 40.586896,
+      "longitude": -73.954155
     },
     {
       "display": "Brighton Beach",
-      "name": "Brighton Beach"
+      "name": "Brighton Beach",
+      "gtfsStopId": "D40",
+      "latitude": 40.577621,
+      "longitude": -73.961376
     },
     {
       "display": "Ocean Parkway",
-      "name": "Ocean Pkwy"
+      "name": "Ocean Pkwy",
+      "gtfsStopId": "D41",
+      "latitude": 40.576312,
+      "longitude": -73.968501
+    },
+    {
+      "display": "West 8th Street-NY Aquarium",
+      "name": "W 8 St-NY Aquarium",
+      "gtfsStopId": "D42",
+      "latitude": 40.576127,
+      "longitude": -73.975939
     },
     {
       "display": "Coney Island-Stillwell Avenue",
-      "name": "Coney Island-Stillwell Av"
+      "name": "Coney Island-Stillwell Av",
+      "gtfsStopId": "D43",
+      "latitude": 40.577422,
+      "longitude": -73.981233
     }
   ],
   "R": [
     {
       "display": "Forest Hills-71st Avenue",
-      "name": "Forest Hills-71 Av"
+      "name": "Forest Hills-71 Av",
+      "gtfsStopId": "G08",
+      "latitude": 40.721691,
+      "longitude": -73.844521
     },
     {
       "display": "67th Avenue",
-      "name": "67 Av"
+      "name": "67 Av",
+      "gtfsStopId": "G09",
+      "latitude": 40.726523,
+      "longitude": -73.852719
     },
     {
       "display": "63rd Drive-Rego Park",
-      "name": "63 Dr-Rego Park"
+      "name": "63 Dr-Rego Park",
+      "gtfsStopId": "G10",
+      "latitude": 40.729846,
+      "longitude": -73.861604
     },
     {
       "display": "Woodhaven Boulevard",
-      "name": "Woodhaven Blvd"
+      "name": "Woodhaven Blvd",
+      "gtfsStopId": "G11",
+      "latitude": 40.733106,
+      "longitude": -73.869229
     },
     {
       "display": "Grand Avenue-Newtown",
-      "name": "Grand Av-Newtown"
+      "name": "Grand Av-Newtown",
+      "gtfsStopId": "G12",
+      "latitude": 40.737015,
+      "longitude": -73.877223
     },
     {
       "display": "Elmhurst Avenue",
-      "name": "Elmhurst Av"
+      "name": "Elmhurst Av",
+      "gtfsStopId": "G13",
+      "latitude": 40.742454,
+      "longitude": -73.882017
     },
     {
       "display": "Jackson Heights-Roosevelt Avenue",
-      "name": "Roosevelt Av / 74 St-Broadway"
+      "name": "Jackson Hts-Roosevelt Av",
+      "gtfsStopId": "G14",
+      "latitude": 40.746644,
+      "longitude": -73.891338
     },
     {
       "display": "65th Street",
-      "name": "65 St"
+      "name": "65 St",
+      "gtfsStopId": "G15",
+      "latitude": 40.749669,
+      "longitude": -73.898453
     },
     {
       "display": "Northern Boulevard",
-      "name": "Northern Blvd"
+      "name": "Northern Blvd",
+      "gtfsStopId": "G16",
+      "latitude": 40.752885,
+      "longitude": -73.906006
     },
     {
       "display": "46th Street",
-      "name": "46 St"
+      "name": "46 St",
+      "gtfsStopId": "G18",
+      "latitude": 40.756312,
+      "longitude": -73.913333
     },
     {
       "display": "Steinway Street",
-      "name": "Steinway St"
-    },
-    {
-      "display": "Queens Plaza",
-      "name": "Queens Plaza"
-    },
-    {
-      "display": "Lexington Avenue-59th Street",
-      "name": "Lexington Av/59 St"
-    },
-    {
-      "display": "5th Avenue-59th Street",
-      "name": "5 Av/59 St"
-    },
-    {
-      "display": "57th Street-7th Avenue",
-      "name": "57 St-7 Av"
-    },
-    {
-      "display": "49th Street",
-      "name": "49 St"
-    },
-    {
-      "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
-    },
-    {
-      "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
-    },
-    {
-      "display": "28th Street",
-      "name": "28 St"
-    },
-    {
-      "display": "23rd Street",
-      "name": "23 St"
-    },
-    {
-      "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
-    },
-    {
-      "display": "8th Street-NYU",
-      "name": "8 St-NYU"
-    },
-    {
-      "display": "Prince Street",
-      "name": "Prince St"
-    },
-    {
-      "display": "Canal Street",
-      "name": "Canal St"
-    },
-    {
-      "display": "City Hall",
-      "name": "City Hall"
-    },
-    {
-      "display": "Cortlandt Street",
-      "name": "Cortlandt St"
-    },
-    {
-      "display": "Rector Street",
-      "name": "Rector St"
-    },
-    {
-      "display": "Whitehall Street-South Ferry",
-      "name": "South Ferry / Whitehall St"
-    },
-    {
-      "display": "Court Street",
-      "name": "Court St / Borough Hall"
-    },
-    {
-      "display": "Jay Street-MetroTech",
-      "name": "Jay St-MetroTech"
-    },
-    {
-      "display": "DeKalb Avenue",
-      "name": "DeKalb Av"
-    },
-    {
-      "display": "Atlantic Avenue-Barclays Center",
-      "name": "Atlantic Av-Barclays Ctr"
-    },
-    {
-      "display": "Union Street",
-      "name": "Union St"
-    },
-    {
-      "display": "4th Avenue-9th Street",
-      "name": "4 Av-9 St"
-    },
-    {
-      "display": "Prospect Avenue",
-      "name": "Prospect Av"
-    },
-    {
-      "display": "25th Street",
-      "name": "25 St"
+      "name": "Steinway St",
+      "gtfsStopId": "G19",
+      "latitude": 40.756879,
+      "longitude": -73.92074
     },
     {
       "display": "36th Street",
-      "name": "36 St"
+      "name": "36 St",
+      "gtfsStopId": "G20",
+      "latitude": 40.752039,
+      "longitude": -73.928781
+    },
+    {
+      "display": "Queens Plaza",
+      "name": "Queens Plaza",
+      "gtfsStopId": "G21",
+      "latitude": 40.748973,
+      "longitude": -73.937243
+    },
+    {
+      "display": "Lexington Avenue-59th Street",
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "R11",
+      "latitude": 40.76266,
+      "longitude": -73.967258
+    },
+    {
+      "display": "5th Avenue-59th Street",
+      "name": "5 Av/59 St",
+      "gtfsStopId": "R13",
+      "latitude": 40.764811,
+      "longitude": -73.973347
+    },
+    {
+      "display": "57th Street-7th Avenue",
+      "name": "57 St-7 Av",
+      "gtfsStopId": "R14",
+      "latitude": 40.764664,
+      "longitude": -73.980658
+    },
+    {
+      "display": "49th Street",
+      "name": "49 St",
+      "gtfsStopId": "R15",
+      "latitude": 40.759901,
+      "longitude": -73.984139
+    },
+    {
+      "display": "Times Square-42nd Street",
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "R16",
+      "latitude": 40.754672,
+      "longitude": -73.986754
+    },
+    {
+      "display": "34th Street-Herald Square",
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "R17",
+      "latitude": 40.749567,
+      "longitude": -73.98795
+    },
+    {
+      "display": "28th Street",
+      "name": "28 St",
+      "gtfsStopId": "R18",
+      "latitude": 40.745494,
+      "longitude": -73.988691
+    },
+    {
+      "display": "23rd Street",
+      "name": "23 St",
+      "gtfsStopId": "R19",
+      "latitude": 40.741303,
+      "longitude": -73.989344
+    },
+    {
+      "display": "14th Street-Union Square",
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "R20",
+      "latitude": 40.735736,
+      "longitude": -73.990568
+    },
+    {
+      "display": "8th Street-NYU",
+      "name": "8 St-NYU",
+      "gtfsStopId": "R21",
+      "latitude": 40.730328,
+      "longitude": -73.992629
+    },
+    {
+      "display": "Prince Street",
+      "name": "Prince St",
+      "gtfsStopId": "R22",
+      "latitude": 40.724329,
+      "longitude": -73.997702
+    },
+    {
+      "display": "Canal Street",
+      "name": "Canal St",
+      "gtfsStopId": "R23",
+      "latitude": 40.719527,
+      "longitude": -74.001775
+    },
+    {
+      "display": "City Hall",
+      "name": "City Hall",
+      "gtfsStopId": "R24",
+      "latitude": 40.713282,
+      "longitude": -74.006978
+    },
+    {
+      "display": "Cortlandt Street",
+      "name": "Cortlandt St",
+      "gtfsStopId": "R25",
+      "latitude": 40.710668,
+      "longitude": -74.011029
+    },
+    {
+      "display": "Rector Street",
+      "name": "Rector St",
+      "gtfsStopId": "R26",
+      "latitude": 40.70722,
+      "longitude": -74.013342
+    },
+    {
+      "display": "Whitehall Street-South Ferry",
+      "name": "South Ferry / Whitehall St",
+      "gtfsStopId": "R27",
+      "latitude": 40.703087,
+      "longitude": -74.012994
+    },
+    {
+      "display": "Court St-Borough Hall",
+      "name": "Court St",
+      "gtfsStopId": "R28",
+      "latitude": 40.6941,
+      "longitude": -73.991777
+    },
+    {
+      "display": "Jay Street-MetroTech",
+      "name": "Jay St-MetroTech",
+      "gtfsStopId": "R29",
+      "latitude": 40.69218,
+      "longitude": -73.985942
+    },
+    {
+      "display": "DeKalb Avenue",
+      "name": "DeKalb Av",
+      "gtfsStopId": "R30",
+      "latitude": 40.690635,
+      "longitude": -73.981824
+    },
+    {
+      "display": "Atlantic Avenue-Barclays Center",
+      "name": "Atlantic Av-Barclays Ctr",
+      "gtfsStopId": "R31",
+      "latitude": 40.683666,
+      "longitude": -73.97881
+    },
+    {
+      "display": "Union Street",
+      "name": "Union St",
+      "gtfsStopId": "R32",
+      "latitude": 40.677316,
+      "longitude": -73.98311
+    },
+    {
+      "display": "4th Avenue-9th Street",
+      "name": "4 Av-9 St",
+      "gtfsStopId": "R33",
+      "latitude": 40.670847,
+      "longitude": -73.988302
+    },
+    {
+      "display": "Prospect Avenue",
+      "name": "Prospect Av",
+      "gtfsStopId": "R34",
+      "latitude": 40.665414,
+      "longitude": -73.992872
+    },
+    {
+      "display": "25th Street",
+      "name": "25 St",
+      "gtfsStopId": "R35",
+      "latitude": 40.660397,
+      "longitude": -73.998091
+    },
+    {
+      "display": "36th Street",
+      "name": "36 St",
+      "gtfsStopId": "R36",
+      "latitude": 40.655144,
+      "longitude": -74.003549
     },
     {
       "display": "45th Street",
-      "name": "45 St"
+      "name": "45 St",
+      "gtfsStopId": "R39",
+      "latitude": 40.648939,
+      "longitude": -74.010006
     },
     {
       "display": "53rd Street",
-      "name": "53 St"
+      "name": "53 St",
+      "gtfsStopId": "R40",
+      "latitude": 40.645069,
+      "longitude": -74.014034
     },
     {
       "display": "59th Street",
-      "name": "59 St"
+      "name": "59 St",
+      "gtfsStopId": "R41",
+      "latitude": 40.641362,
+      "longitude": -74.017881
     },
     {
       "display": "Bay Ridge Avenue",
-      "name": "Bay Ridge Av"
+      "name": "Bay Ridge Av",
+      "gtfsStopId": "R42",
+      "latitude": 40.634967,
+      "longitude": -74.023377
     },
     {
       "display": "77th Street",
-      "name": "77 St"
+      "name": "77 St",
+      "gtfsStopId": "R43",
+      "latitude": 40.629742,
+      "longitude": -74.02551
     },
     {
       "display": "86th Street",
-      "name": "86 St"
+      "name": "86 St",
+      "gtfsStopId": "R44",
+      "latitude": 40.622687,
+      "longitude": -74.028398
     },
     {
       "display": "Bay Ridge-95th Street",
-      "name": "Bay Ridge-95 St"
+      "name": "Bay Ridge-95 St",
+      "gtfsStopId": "R45",
+      "latitude": 40.616622,
+      "longitude": -74.030876
     }
   ],
   "W": [
     {
       "display": "Astoria-Ditmars Boulevard",
-      "name": "Astoria-Ditmars Blvd"
+      "name": "Astoria-Ditmars Blvd",
+      "gtfsStopId": "R01",
+      "latitude": 40.775036,
+      "longitude": -73.912034
     },
     {
       "display": "Astoria Boulevard",
-      "name": "Astoria Blvd"
+      "name": "Astoria Blvd",
+      "gtfsStopId": "R03",
+      "latitude": 40.770258,
+      "longitude": -73.917843
     },
     {
       "display": "30th Avenue",
-      "name": "30 Av"
+      "name": "30 Av",
+      "gtfsStopId": "R04",
+      "latitude": 40.766779,
+      "longitude": -73.921479
     },
     {
       "display": "Broadway",
-      "name": "Broadway"
+      "name": "Broadway",
+      "gtfsStopId": "R05",
+      "latitude": 40.76182,
+      "longitude": -73.925508
     },
     {
       "display": "36th Avenue",
-      "name": "36 Av"
+      "name": "36 Av",
+      "gtfsStopId": "R06",
+      "latitude": 40.756804,
+      "longitude": -73.929575
     },
     {
       "display": "39th Avenue",
-      "name": "39 Av"
+      "name": "39 Av",
+      "gtfsStopId": "R08",
+      "latitude": 40.752882,
+      "longitude": -73.932755
     },
     {
       "display": "Queensboro Plaza",
-      "name": "Queensboro Plaza"
+      "name": "Queensboro Plaza",
+      "gtfsStopId": "R09",
+      "latitude": 40.750582,
+      "longitude": -73.940202
     },
     {
       "display": "Lexington Avenue-59th Street",
-      "name": "Lexington Av/59 St"
+      "name": "Lexington Av/59 St",
+      "gtfsStopId": "R11",
+      "latitude": 40.76266,
+      "longitude": -73.967258
     },
     {
       "display": "5th Avenue-59th Street",
-      "name": "5 Av/59 St"
+      "name": "5 Av/59 St",
+      "gtfsStopId": "R13",
+      "latitude": 40.764811,
+      "longitude": -73.973347
     },
     {
       "display": "57th Street-7th Avenue",
-      "name": "57 St-7 Av"
+      "name": "57 St-7 Av",
+      "gtfsStopId": "R14",
+      "latitude": 40.764664,
+      "longitude": -73.980658
     },
     {
       "display": "49th Street",
-      "name": "49 St"
+      "name": "49 St",
+      "gtfsStopId": "R15",
+      "latitude": 40.759901,
+      "longitude": -73.984139
     },
     {
       "display": "Times Square-42nd Street",
-      "name": "Times Sq-42 St"
+      "name": "Times Sq-42 St",
+      "gtfsStopId": "R16",
+      "latitude": 40.754672,
+      "longitude": -73.986754
     },
     {
       "display": "34th Street-Herald Square",
-      "name": "34 St-Herald Sq"
+      "name": "34 St-Herald Sq",
+      "gtfsStopId": "R17",
+      "latitude": 40.749567,
+      "longitude": -73.98795
     },
     {
       "display": "28th Street",
-      "name": "28 St"
+      "name": "28 St",
+      "gtfsStopId": "R18",
+      "latitude": 40.745494,
+      "longitude": -73.988691
     },
     {
       "display": "23rd Street",
-      "name": "23 St"
+      "name": "23 St",
+      "gtfsStopId": "R19",
+      "latitude": 40.741303,
+      "longitude": -73.989344
     },
     {
       "display": "14th Street-Union Square",
-      "name": "14 St-Union Sq"
+      "name": "14 St-Union Sq",
+      "gtfsStopId": "R20",
+      "latitude": 40.735736,
+      "longitude": -73.990568
     },
     {
       "display": "8th Street-NYU",
-      "name": "8 St-NYU"
+      "name": "8 St-NYU",
+      "gtfsStopId": "R21",
+      "latitude": 40.730328,
+      "longitude": -73.992629
     },
     {
       "display": "Prince Street",
-      "name": "Prince St"
+      "name": "Prince St",
+      "gtfsStopId": "R22",
+      "latitude": 40.724329,
+      "longitude": -73.997702
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "R23",
+      "latitude": 40.719527,
+      "longitude": -74.001775
     },
     {
       "display": "City Hall",
-      "name": "City Hall"
+      "name": "City Hall",
+      "gtfsStopId": "R24",
+      "latitude": 40.713282,
+      "longitude": -74.006978
     },
     {
       "display": "Cortlandt Street",
-      "name": "Cortlandt St"
+      "name": "Cortlandt St",
+      "gtfsStopId": "R25",
+      "latitude": 40.710668,
+      "longitude": -74.011029
     },
     {
       "display": "Rector Street",
-      "name": "Rector St"
+      "name": "Rector St",
+      "gtfsStopId": "R26",
+      "latitude": 40.70722,
+      "longitude": -74.013342
     },
     {
       "display": "Whitehall Street-South Ferry",
-      "name": "South Ferry / Whitehall St"
+      "name": "South Ferry / Whitehall St",
+      "gtfsStopId": "R27",
+      "latitude": 40.703087,
+      "longitude": -74.012994
     }
   ],
   "Z": [
     {
       "display": "Jamaica Center-Parsons/Archer",
-      "name": "Jamaica Center-Parsons/Archer"
+      "name": "Jamaica Center-Parsons/Archer",
+      "gtfsStopId": "G05",
+      "latitude": 40.702147,
+      "longitude": -73.801109
     },
     {
       "display": "Sutphin Boulevard-Archer Avenue-JFK Airport",
-      "name": "Sutphin Blvd-Archer Av-JFK Airport"
+      "name": "Sutphin Blvd-Archer Av-JFK Airport",
+      "gtfsStopId": "G06",
+      "latitude": 40.700486,
+      "longitude": -73.807969
     },
     {
       "display": "121st Street",
-      "name": "121 St"
+      "name": "121 St",
+      "gtfsStopId": "J12",
+      "latitude": 40.700492,
+      "longitude": -73.828294
     },
     {
       "display": "111th Street",
-      "name": "111 St"
+      "name": "111 St",
+      "gtfsStopId": "J13",
+      "latitude": 40.697418,
+      "longitude": -73.836345
     },
     {
       "display": "104th Street",
-      "name": "104 St"
+      "name": "104 St",
+      "gtfsStopId": "J14",
+      "latitude": 40.695178,
+      "longitude": -73.84433
     },
     {
       "display": "Woodhaven Boulevard",
-      "name": "Woodhaven Blvd"
+      "name": "Woodhaven Blvd",
+      "gtfsStopId": "J15",
+      "latitude": 40.693879,
+      "longitude": -73.851576
     },
     {
       "display": "85th Street-Forest Parkway",
-      "name": "85 St-Forest Pkwy"
+      "name": "85 St-Forest Pkwy",
+      "gtfsStopId": "J16",
+      "latitude": 40.692435,
+      "longitude": -73.86001
     },
     {
       "display": "75th Street-Elderts Lane",
-      "name": "75 St-Elderts Ln"
+      "name": "75 St-Elderts Ln",
+      "gtfsStopId": "J17",
+      "latitude": 40.691324,
+      "longitude": -73.867139
     },
     {
       "display": "Cypress Hills",
-      "name": "Cypress Hills"
+      "name": "Cypress Hills",
+      "gtfsStopId": "J19",
+      "latitude": 40.689941,
+      "longitude": -73.87255
     },
     {
       "display": "Crescent Street",
-      "name": "Crescent St"
+      "name": "Crescent St",
+      "gtfsStopId": "J20",
+      "latitude": 40.683194,
+      "longitude": -73.873785
     },
     {
       "display": "Norwood Avenue",
-      "name": "Norwood Av"
+      "name": "Norwood Av",
+      "gtfsStopId": "J21",
+      "latitude": 40.68141,
+      "longitude": -73.880039
     },
     {
       "display": "Cleveland Street",
-      "name": "Cleveland St"
+      "name": "Cleveland St",
+      "gtfsStopId": "J22",
+      "latitude": 40.679947,
+      "longitude": -73.884639
     },
     {
       "display": "Van Siclen Avenue",
-      "name": "Van Siclen Av"
+      "name": "Van Siclen Av",
+      "gtfsStopId": "J23",
+      "latitude": 40.678024,
+      "longitude": -73.891688
     },
     {
       "display": "Alabama Avenue",
-      "name": "Alabama Av"
+      "name": "Alabama Av",
+      "gtfsStopId": "J24",
+      "latitude": 40.676992,
+      "longitude": -73.898654
     },
     {
       "display": "Broadway Junction",
-      "name": "Broadway Junction"
+      "name": "Broadway Junction",
+      "gtfsStopId": "J27",
+      "latitude": 40.679498,
+      "longitude": -73.904512
     },
     {
       "display": "Chauncey Street",
-      "name": "Chauncey St"
+      "name": "Chauncey St",
+      "gtfsStopId": "J28",
+      "latitude": 40.682893,
+      "longitude": -73.910456
     },
     {
       "display": "Halsey Street",
-      "name": "Halsey St"
+      "name": "Halsey St",
+      "gtfsStopId": "J29",
+      "latitude": 40.68637,
+      "longitude": -73.916559
     },
     {
       "display": "Gates Avenue",
-      "name": "Gates Av"
+      "name": "Gates Av",
+      "gtfsStopId": "J30",
+      "latitude": 40.68963,
+      "longitude": -73.92227
     },
     {
       "display": "Kosciuszko Street",
-      "name": "Kosciuszko St"
+      "name": "Kosciuszko St",
+      "gtfsStopId": "J31",
+      "latitude": 40.693342,
+      "longitude": -73.928814
     },
     {
       "display": "Myrtle Avenue",
-      "name": "Myrtle Av"
+      "name": "Myrtle Av",
+      "gtfsStopId": "M11",
+      "latitude": 40.697207,
+      "longitude": -73.935657
     },
     {
       "display": "Flushing Avenue",
-      "name": "Flushing Av"
+      "name": "Flushing Av",
+      "gtfsStopId": "M12",
+      "latitude": 40.70026,
+      "longitude": -73.941126
     },
     {
       "display": "Lorimer Street",
-      "name": "Lorimer St"
+      "name": "Lorimer St",
+      "gtfsStopId": "M13",
+      "latitude": 40.703869,
+      "longitude": -73.947408
     },
     {
       "display": "Hewes Street",
-      "name": "Hewes St"
+      "name": "Hewes St",
+      "gtfsStopId": "M14",
+      "latitude": 40.70687,
+      "longitude": -73.953431
     },
     {
       "display": "Marcy Avenue",
-      "name": "Marcy Av"
+      "name": "Marcy Av",
+      "gtfsStopId": "M16",
+      "latitude": 40.708359,
+      "longitude": -73.957757
     },
     {
       "display": "Delancey Street-Essex Street",
-      "name": "Delancey St-Essex St"
+      "name": "Delancey St-Essex St",
+      "gtfsStopId": "M18",
+      "latitude": 40.718315,
+      "longitude": -73.987437
     },
     {
       "display": "Bowery",
-      "name": "Bowery"
+      "name": "Bowery",
+      "gtfsStopId": "M19",
+      "latitude": 40.72028,
+      "longitude": -73.993915
     },
     {
       "display": "Canal Street",
-      "name": "Canal St"
+      "name": "Canal St",
+      "gtfsStopId": "M20",
+      "latitude": 40.718092,
+      "longitude": -73.999892
     },
     {
       "display": "Chambers Street",
-      "name": "Brooklyn Bridge-City Hall / Chambers St"
+      "name": "Brooklyn Bridge-City Hall / Chambers St",
+      "gtfsStopId": "M21",
+      "latitude": 40.713243,
+      "longitude": -74.003401
     },
     {
       "display": "Fulton Street",
-      "name": "Fulton St"
+      "name": "Fulton St",
+      "gtfsStopId": "M22",
+      "latitude": 40.710374,
+      "longitude": -74.007582
     },
     {
       "display": "Broad Street",
-      "name": "Broad St"
+      "name": "Broad St",
+      "gtfsStopId": "M23",
+      "latitude": 40.706476,
+      "longitude": -74.011056
     }
   ]
 }

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/GTFSRTParser.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/GTFSRTParser.kt
@@ -1,0 +1,311 @@
+package com.move38.nowdeparting.data.api
+
+import java.time.Instant
+
+//
+//  GTFSRTParser.kt
+//  Now Departing
+//
+//  A minimal binary Protocol Buffers decoder for GTFS-RT feeds.
+//
+//  Decodes only the subset of the GTFS-RT schema the app uses:
+//
+//    FeedMessage
+//      └─ entity[]          (FeedEntity, field 2)
+//           └─ trip_update  (TripUpdate, field 3)
+//                ├─ trip    (TripDescriptor, field 1)
+//                │    ├─ trip_id      (string, field 1)
+//                │    ├─ route_id     (string, field 5)
+//                │    └─ direction_id (uint32, field 9)
+//                └─ stop_time_update[] (StopTimeUpdate, field 2)
+//                     ├─ stop_id  (string, field 4)
+//                     ├─ arrival  (StopTimeEvent, field 2)
+//                     │    └─ time (int64, field 2) — Unix timestamp
+//                     └─ departure (StopTimeEvent, field 3)
+//                          └─ time (int64, field 2) — Unix timestamp
+//
+
+data class GTFSTripUpdate(
+    val routeId: String,
+    val tripId: String,
+    val directionId: Int?,
+    val stopTimeUpdates: List<GTFSStopTimeUpdate>
+)
+
+data class GTFSStopTimeUpdate(
+    val stopId: String,
+    val arrivalTime: Instant?,
+    val departureTime: Instant?
+)
+
+class GTFSRTParser {
+
+    sealed class ParseError : Exception() {
+        object InvalidData : ParseError()
+        object TruncatedMessage : ParseError()
+    }
+
+    private enum class WireType(val value: Int) {
+        VARINT(0),
+        FIXED64(1),
+        LENGTH_DELIMITED(2),
+        FIXED32(5);
+
+        companion object {
+            fun fromInt(value: Int): WireType? = values().find { it.value == value }
+        }
+    }
+
+    fun parse(data: ByteArray): List<GTFSTripUpdate> {
+        val updates = mutableListOf<GTFSTripUpdate>()
+        var offset = 0
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            // FeedMessage.entity is field 2, wire-type length-delimited.
+            if (fieldNumber == 2 && wireType == WireType.LENGTH_DELIMITED) {
+                val (entityData, afterEntity) = readBytes(data, offset)
+                offset = afterEntity
+                parseFeedEntity(entityData)?.let { updates.add(it) }
+            } else {
+                offset = skip(data, offset, wireType)
+            }
+        }
+
+        return updates
+    }
+
+    private fun parseFeedEntity(data: ByteArray): GTFSTripUpdate? {
+        var offset = 0
+        var result: GTFSTripUpdate? = null
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            // FeedEntity.trip_update is field 3.
+            if (fieldNumber == 3 && wireType == WireType.LENGTH_DELIMITED) {
+                val (tuData, afterTU) = readBytes(data, offset)
+                offset = afterTU
+                result = parseTripUpdate(tuData)
+            } else {
+                offset = skip(data, offset, wireType)
+            }
+        }
+
+        return result
+    }
+
+    private fun parseTripUpdate(data: ByteArray): GTFSTripUpdate? {
+        var offset = 0
+        var routeId = ""
+        var tripId = ""
+        var directionId: Int? = null
+        val stopTimeUpdates = mutableListOf<GTFSStopTimeUpdate>()
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            when (fieldNumber) {
+                1 -> { // TripUpdate.trip (TripDescriptor)
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (tdData, afterTD) = readBytes(data, offset)
+                        offset = afterTD
+                        val td = parseTripDescriptor(tdData)
+                        routeId = td.routeId
+                        tripId = td.tripId
+                        directionId = td.directionId
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                2 -> { // TripUpdate.stop_time_update (repeated)
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (stuData, afterSTU) = readBytes(data, offset)
+                        offset = afterSTU
+                        parseStopTimeUpdate(stuData)?.let { stopTimeUpdates.add(it) }
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                else -> offset = skip(data, offset, wireType)
+            }
+        }
+
+        if (routeId.isEmpty()) return null
+        return GTFSTripUpdate(routeId, tripId, directionId, stopTimeUpdates)
+    }
+
+    private data class TripDescriptorResult(val routeId: String, val tripId: String, val directionId: Int?)
+
+    private fun parseTripDescriptor(data: ByteArray): TripDescriptorResult {
+        var offset = 0
+        var routeId = ""
+        var tripId = ""
+        var directionId: Int? = null
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            when (fieldNumber) {
+                1 -> { // trip_id
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (bytes, after) = readBytes(data, offset)
+                        offset = after
+                        tripId = String(bytes, Charsets.UTF_8)
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                5 -> { // route_id
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (bytes, after) = readBytes(data, offset)
+                        offset = after
+                        routeId = String(bytes, Charsets.UTF_8)
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                9 -> { // direction_id (uint32)
+                    if (wireType == WireType.VARINT) {
+                        val (value, after) = readVarint(data, offset)
+                        offset = after
+                        directionId = value.toInt()
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                else -> offset = skip(data, offset, wireType)
+            }
+        }
+
+        return TripDescriptorResult(routeId, tripId, directionId)
+    }
+
+    private fun parseStopTimeUpdate(data: ByteArray): GTFSStopTimeUpdate? {
+        var offset = 0
+        var stopId = ""
+        var arrivalTime: Instant? = null
+        var departureTime: Instant? = null
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            when (fieldNumber) {
+                2 -> { // arrival (StopTimeEvent)
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (steData, after) = readBytes(data, offset)
+                        offset = after
+                        arrivalTime = parseStopTimeEvent(steData)
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                3 -> { // departure (StopTimeEvent)
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (steData, after) = readBytes(data, offset)
+                        offset = after
+                        departureTime = parseStopTimeEvent(steData)
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                4 -> { // stop_id (string)
+                    if (wireType == WireType.LENGTH_DELIMITED) {
+                        val (bytes, after) = readBytes(data, offset)
+                        offset = after
+                        stopId = String(bytes, Charsets.UTF_8)
+                    } else {
+                        offset = skip(data, offset, wireType)
+                    }
+                }
+                else -> offset = skip(data, offset, wireType)
+            }
+        }
+
+        if (stopId.isEmpty()) return null
+        return GTFSStopTimeUpdate(stopId, arrivalTime, departureTime)
+    }
+
+    private fun parseStopTimeEvent(data: ByteArray): Instant? {
+        var offset = 0
+        var timestamp: Long? = null
+
+        while (offset < data.size) {
+            val (fieldNumber, wireType, afterTag) = readTag(data, offset)
+            offset = afterTag
+
+            // StopTimeEvent.time is field 2 (int64 encoded as varint).
+            if (fieldNumber == 2 && wireType == WireType.VARINT) {
+                val (value, after) = readVarint(data, offset)
+                offset = after
+                timestamp = value.toLong()
+            } else {
+                offset = skip(data, offset, wireType)
+            }
+        }
+
+        return timestamp?.let { Instant.ofEpochSecond(it) }
+    }
+
+    // MARK: - Protobuf Wire Primitives
+
+    private data class TagResult(val fieldNumber: Int, val wireType: WireType, val offset: Int)
+
+    private fun readTag(data: ByteArray, offset: Int): TagResult {
+        val (raw, after) = readVarint(data, offset)
+        val fieldNumber = (raw shr 3).toInt()
+        if (fieldNumber <= 0) throw ParseError.InvalidData
+        val wireType = WireType.fromInt((raw and 0x07UL).toInt()) ?: throw ParseError.InvalidData
+        return TagResult(fieldNumber, wireType, after)
+    }
+
+    private data class VarintResult(val value: ULong, val offset: Int)
+
+    private fun readVarint(data: ByteArray, start: Int): VarintResult {
+        var result = 0UL
+        var shift = 0
+        var offset = start
+
+        while (offset < data.size) {
+            val byte = data[offset].toInt() and 0xFF
+            offset++
+            result = result or ((byte and 0x7F).toULong() shl shift)
+            if (byte and 0x80 == 0) {
+                return VarintResult(result, offset)
+            }
+            shift += 7
+            if (shift >= 64) throw ParseError.InvalidData
+        }
+        throw ParseError.TruncatedMessage
+    }
+
+    private data class BytesResult(val data: ByteArray, val offset: Int)
+
+    private fun readBytes(data: ByteArray, offset: Int): BytesResult {
+        val (length, afterLength) = readVarint(data, offset)
+        val end = afterLength + length.toInt()
+        if (end > data.size) throw ParseError.TruncatedMessage
+        return BytesResult(data.copyOfRange(afterLength, end), end)
+    }
+
+    private fun skip(data: ByteArray, offset: Int, wireType: WireType): Int {
+        return when (wireType) {
+            WireType.VARINT -> readVarint(data, offset).offset
+            WireType.FIXED64 -> {
+                if (offset + 8 > data.size) throw ParseError.TruncatedMessage
+                offset + 8
+            }
+            WireType.LENGTH_DELIMITED -> readBytes(data, offset).offset
+            WireType.FIXED32 -> {
+                if (offset + 4 > data.size) throw ParseError.TruncatedMessage
+                offset + 4
+            }
+        }
+    }
+}

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/MTAFeedConfiguration.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/MTAFeedConfiguration.kt
@@ -1,0 +1,68 @@
+package com.move38.nowdeparting.data.api
+
+object MTAFeedConfiguration {
+
+    private const val BASE_URL = "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2F"
+
+    // Multiple routes share a single feed file; fetching any route from the
+    // group retrieves real-time data for every route in that group.
+    //
+    // Feed groups:
+    //   gtfs      → 1 2 3 4 5 6 7 GS (numbered lines + 42nd St Shuttle)
+    //   gtfs-ace  → A C E FS (Franklin Ave Shuttle) H (Rockaway Park)
+    //   gtfs-bdfm → B D F M
+    //   gtfs-g    → G
+    //   gtfs-jz   → J Z
+    //   gtfs-nqrw → N Q R W
+    //   gtfs-l    → L
+    //   gtfs-si   → SI (Staten Island Railway)
+
+    private val feedPathByRoute = mapOf(
+        "1"  to "gtfs",
+        "2"  to "gtfs",
+        "3"  to "gtfs",
+        "4"  to "gtfs",
+        "5"  to "gtfs",
+        "6"  to "gtfs",
+        "7"  to "gtfs",
+        "GS" to "gtfs",
+        "A"  to "gtfs-ace",
+        "C"  to "gtfs-ace",
+        "E"  to "gtfs-ace",
+        "FS" to "gtfs-ace",
+        "H"  to "gtfs-ace",
+        "B"  to "gtfs-bdfm",
+        "D"  to "gtfs-bdfm",
+        "F"  to "gtfs-bdfm",
+        "M"  to "gtfs-bdfm",
+        "G"  to "gtfs-g",
+        "J"  to "gtfs-jz",
+        "Z"  to "gtfs-jz",
+        "N"  to "gtfs-nqrw",
+        "Q"  to "gtfs-nqrw",
+        "R"  to "gtfs-nqrw",
+        "W"  to "gtfs-nqrw",
+        "L"  to "gtfs-l",
+        "SI" to "gtfs-si"
+    )
+
+    /** Returns the GTFS-RT feed URL for a given route ID, or null if unknown. */
+    fun feedUrl(routeId: String): String? {
+        val path = feedPathByRoute[routeId] ?: return null
+        return "$BASE_URL$path"
+    }
+
+    /** Returns deduplicated feed URLs for a set of route IDs. Routes that share
+     *  a feed file are collapsed to a single URL. */
+    fun feedUrls(routeIds: List<String>): List<String> {
+        val seenPaths = mutableSetOf<String>()
+        val urls = mutableListOf<String>()
+        for (routeId in routeIds) {
+            val path = feedPathByRoute[routeId] ?: continue
+            if (seenPaths.add(path)) {
+                urls.add("$BASE_URL$path")
+            }
+        }
+        return urls
+    }
+}

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/MTAFeedService.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/api/MTAFeedService.kt
@@ -1,0 +1,244 @@
+package com.move38.nowdeparting.data.api
+
+import android.location.Location
+import android.util.Log
+import com.move38.nowdeparting.data.model.Station
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class MTANearbyArrival(
+    val routeId: String,
+    val gtfsStopId: String?,
+    val stationName: String,
+    val stationDisplay: String,
+    val direction: String,
+    val arrivalTime: Instant,
+    val distanceInMeters: Double
+)
+
+sealed class MTAFeedError : Exception() {
+    data class MissingStopId(val stationName: String) : MTAFeedError()
+    data class NetworkError(override val cause: Throwable) : MTAFeedError()
+    data class HttpError(val code: Int) : MTAFeedError()
+    data class ParseError(override val cause: Throwable) : MTAFeedError()
+    object NoData : MTAFeedError()
+}
+
+@Singleton
+class MTAFeedService @Inject constructor(
+    private val okHttpClient: OkHttpClient
+) {
+    companion object {
+        private const val TAG = "MTAFeedService"
+        private const val CACHE_TTL_MS = 30_000L  // GTFS-RT feeds refresh ~every 30s
+    }
+
+    private val parser = GTFSRTParser()
+    // Cache: feed URL → (fetchTimeMs, parsedUpdates)
+    private val cache = ConcurrentHashMap<String, Pair<Long, List<GTFSTripUpdate>>>()
+
+    // MARK: - By-Station Query
+
+    /** Fetches arrival times at a specific station for a given route and direction. */
+    suspend fun fetchArrivals(
+        routeId: String,
+        station: Station,
+        direction: String
+    ): Result<List<Instant>> = withContext(Dispatchers.IO) {
+        val parentStopId = station.gtfsStopId
+        if (parentStopId.isNullOrEmpty()) {
+            return@withContext Result.failure(MTAFeedError.MissingStopId(station.name))
+        }
+
+        val targetStopId = parentStopId + direction  // e.g. "127" + "N" → "127N"
+
+        fetchFeed(routeId).map { updates ->
+            val now = Instant.now()
+            updates
+                .filter { it.routeId == routeId }
+                .flatMap { update ->
+                    update.stopTimeUpdates
+                        .filter { it.stopId == targetStopId }
+                        .mapNotNull { it.arrivalTime ?: it.departureTime }
+                }
+                .filter { it.isAfter(now) }
+                .sorted()
+        }
+    }
+
+    // MARK: - By-Location Query
+
+    /** Fetches all arrivals within radiusMeters of the given location across every
+     *  feed group. Returns raw MTANearbyArrival values. */
+    suspend fun fetchNearbyArrivals(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Float = 1600f,
+        stationsByLine: Map<String, List<Station>>
+    ): Result<List<MTANearbyArrival>> = withContext(Dispatchers.IO) {
+        data class NearbyStop(val station: Station, val distance: Float)
+
+        val nearbyStops = mutableListOf<NearbyStop>()
+        val seenNames = mutableSetOf<String>()
+
+        for (stations in stationsByLine.values) {
+            for (station in stations) {
+                if (!seenNames.add(station.name)) continue
+                station.gtfsStopId ?: continue
+                val lat = station.latitude ?: continue
+                val lon = station.longitude ?: continue
+
+                val distResults = FloatArray(1)
+                Location.distanceBetween(latitude, longitude, lat, lon, distResults)
+                if (distResults[0] <= radiusMeters) {
+                    nearbyStops.add(NearbyStop(station, distResults[0]))
+                }
+            }
+        }
+
+        if (nearbyStops.isEmpty()) return@withContext Result.success(emptyList())
+
+        val feedUrls = MTAFeedConfiguration.feedUrls(stationsByLine.keys.toList())
+
+        coroutineScope {
+            val feedResults = feedUrls.map { url ->
+                async { fetchFeedData(url) }
+            }.map { it.await() }
+
+            val allUpdates = mutableListOf<GTFSTripUpdate>()
+            var firstError: MTAFeedError? = null
+
+            for (result in feedResults) {
+                result.fold(
+                    onSuccess = { allUpdates.addAll(it) },
+                    onFailure = { if (firstError == null) firstError = it as? MTAFeedError }
+                )
+            }
+
+            if (allUpdates.isEmpty() && firstError != null) {
+                return@coroutineScope Result.failure(firstError!!)
+            }
+
+            val now = Instant.now()
+            val results = mutableListOf<MTANearbyArrival>()
+
+            for (stop in nearbyStops) {
+                for (dir in listOf("N", "S")) {
+                    val parentId = stop.station.gtfsStopId ?: continue
+                    val stopId = parentId + dir
+
+                    for (update in allUpdates) {
+                        for (stu in update.stopTimeUpdates) {
+                            if (stu.stopId != stopId) continue
+                            val arrivalTime = stu.arrivalTime ?: stu.departureTime ?: continue
+                            if (!arrivalTime.isAfter(now)) continue
+                            val minutesAway = (arrivalTime.epochSecond - now.epochSecond) / 60
+                            if (minutesAway < 0 || minutesAway > 30) continue
+
+                            results.add(
+                                MTANearbyArrival(
+                                    routeId = update.routeId,
+                                    gtfsStopId = stop.station.gtfsStopId,
+                                    stationName = stop.station.name,
+                                    stationDisplay = stop.station.display,
+                                    direction = dir,
+                                    arrivalTime = arrivalTime,
+                                    distanceInMeters = stop.distance.toDouble()
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Sort: primarily by arrival time; secondarily by distance when times
+            // are within 1 minute of each other.
+            val sorted = results.sortedWith { a, b ->
+                val tA = a.arrivalTime.epochSecond - now.epochSecond
+                val tB = b.arrivalTime.epochSecond - now.epochSecond
+                if (Math.abs(tA - tB) < 60) a.distanceInMeters.compareTo(b.distanceInMeters)
+                else tA.compareTo(tB)
+            }
+
+            Result.success(sorted)
+        }
+    }
+
+    // MARK: - Availability Check
+
+    /** Checks which stations on a line have live arrivals and updates hasAvailableTimes. */
+    suspend fun checkAvailability(
+        lineId: String,
+        stations: List<Station>
+    ): List<Station> = withContext(Dispatchers.IO) {
+        val result = fetchFeed(lineId)
+        if (result.isFailure) return@withContext stations
+
+        val updates = result.getOrDefault(emptyList())
+        val activeStopIds = updates
+            .filter { it.routeId == lineId }
+            .flatMapTo(mutableSetOf()) { update ->
+                update.stopTimeUpdates.map { it.stopId }
+            }
+
+        stations.map { station ->
+            val parentId = station.gtfsStopId
+            val hasData = if (parentId != null) {
+                activeStopIds.contains(parentId + "N") || activeStopIds.contains(parentId + "S")
+            } else {
+                false
+            }
+            station.copy(hasAvailableTimes = hasData)
+        }
+    }
+
+    // MARK: - Feed Fetch + Cache
+
+    private suspend fun fetchFeed(routeId: String): Result<List<GTFSTripUpdate>> {
+        val url = MTAFeedConfiguration.feedUrl(routeId)
+            ?: return Result.failure(
+                MTAFeedError.NetworkError(IllegalArgumentException("Unknown route: $routeId"))
+            )
+        return fetchFeedData(url)
+    }
+
+    /** Fetches and parses a GTFS-RT feed, using the in-memory cache when fresh.
+     *  Must be called from a background thread (uses blocking OkHttp execute()). */
+    private fun fetchFeedData(url: String): Result<List<GTFSTripUpdate>> {
+        val cached = cache[url]
+        if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
+            return Result.success(cached.second)
+        }
+
+        return try {
+            val request = Request.Builder().url(url).build()
+            val response = okHttpClient.newCall(request).execute()
+
+            if (!response.isSuccessful) {
+                return Result.failure(MTAFeedError.HttpError(response.code))
+            }
+
+            val bytes = response.body?.bytes()
+            if (bytes == null || bytes.isEmpty()) {
+                return Result.failure(MTAFeedError.NoData)
+            }
+
+            val updates = parser.parse(bytes)
+            cache[url] = Pair(System.currentTimeMillis(), updates)
+            Result.success(updates)
+        } catch (e: GTFSRTParser.ParseError) {
+            Result.failure(MTAFeedError.ParseError(e))
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching feed: $url", e)
+            Result.failure(MTAFeedError.NetworkError(e))
+        }
+    }
+}

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/model/Station.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/model/Station.kt
@@ -6,6 +6,9 @@ import kotlinx.serialization.Serializable
 data class Station(
     val name: String,
     val display: String = "",
+    val gtfsStopId: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
     val hasAvailableTimes: Boolean = true
 ) {
     val id: String get() = name

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/repository/SubwayRepository.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/data/repository/SubwayRepository.kt
@@ -2,21 +2,19 @@ package com.move38.nowdeparting.data.repository
 
 import android.content.Context
 import android.util.Log
-import com.move38.nowdeparting.data.api.MtaApiService
+import com.move38.nowdeparting.data.api.MTAFeedService
 import com.move38.nowdeparting.data.model.*
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.time.Instant
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class SubwayRepository @Inject constructor(
-    private val apiService: MtaApiService,
+    private val mtaFeedService: MTAFeedService,
     @ApplicationContext private val context: Context
 ) {
     private val json = Json { ignoreUnknownKeys = true }
@@ -28,11 +26,16 @@ class SubwayRepository @Inject constructor(
 
     private var cachedStations: Map<String, List<Station>>? = null
 
-    suspend fun getStationsForLine(lineId: String): List<Station> {
+    private suspend fun getAllStations(): Map<String, List<Station>> {
         if (cachedStations == null) {
             cachedStations = loadStationsData()
         }
-        return cachedStations?.get(lineId) ?: emptyList()
+        return cachedStations ?: emptyMap()
+    }
+
+    suspend fun getStationsForLine(lineId: String): List<Station> {
+        val stations = getAllStations()[lineId] ?: emptyList()
+        return mtaFeedService.checkAvailability(lineId, stations)
     }
 
     private suspend fun loadStationsData(): Map<String, List<Station>> = withContext(Dispatchers.IO) {
@@ -50,114 +53,38 @@ class SubwayRepository @Inject constructor(
         stationName: String,
         direction: String
     ): Result<List<Instant>> = withContext(Dispatchers.IO) {
-        try {
-            val response = apiService.getTrainsByRoute(lineId)
-            // Find the station by name in the list
-            val stationData = response.data.find { it.name == stationName }
+        val station = getAllStations()[lineId]?.find { it.name == stationName }
+            ?: return@withContext Result.failure(Exception("Station not found: $stationName"))
 
-            if (stationData == null) {
-                return@withContext Result.success(emptyList())
-            }
-
-            val trains = when (direction) {
-                "N" -> stationData.N
-                "S" -> stationData.S
-                else -> emptyList()
-            }
-
-            val times = trains
-                .filter { it.route == lineId }
-                .mapNotNull { it.arrivalTime }
-                .filter { it.isAfter(Instant.now().minusSeconds(120)) }
-                .sorted()
-
-            Result.success(times)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching train times", e)
-            Result.failure(e)
-        }
+        mtaFeedService.fetchArrivals(lineId, station, direction)
     }
 
     suspend fun getNearbyTrains(
         latitude: Double,
         longitude: Double
     ): Result<List<NearbyTrain>> = withContext(Dispatchers.IO) {
-        try {
-            val response = apiService.getTrainsByLocation(latitude, longitude)
-            val trains = mutableListOf<NearbyTrain>()
+        val allStations = getAllStations()
 
-            for (stationData in response.data) {
-                // Calculate distance from user location to station
-                val distanceResults = FloatArray(1)
-                android.location.Location.distanceBetween(
-                    latitude, longitude,
-                    stationData.latitude, stationData.longitude,
-                    distanceResults
-                )
-                val distanceInMeters = distanceResults[0].toDouble()
-
-                // Process North-bound trains
-                for (trainData in stationData.N) {
-                    // Skip unknown routes (shuttles, express variants, etc.)
-                    if (!DirectionHelper.isValidRoute(trainData.route)) continue
-                    val arrivalTime = parseTime(trainData.time) ?: continue
-                    if (arrivalTime.isBefore(Instant.now().minusSeconds(120))) continue
-
-                    trains.add(
-                        NearbyTrain(
-                            lineId = trainData.route,
-                            stationId = stationData.id.ifEmpty { stationData.name },
-                            stationName = stationData.name,
-                            stationDisplay = stationData.name,
-                            direction = "N",
-                            destination = DirectionHelper.getDestination(trainData.route, "N"),
-                            generalDirection = DirectionHelper.getGeneralDirection(trainData.route, "N"),
-                            arrivalTime = arrivalTime,
-                            distanceInMeters = distanceInMeters
-                        )
+        mtaFeedService.fetchNearbyArrivals(
+            latitude = latitude,
+            longitude = longitude,
+            stationsByLine = allStations
+        ).map { arrivals ->
+            arrivals
+                .filter { DirectionHelper.isValidRoute(it.routeId) }
+                .map { arrival ->
+                    NearbyTrain(
+                        lineId = arrival.routeId,
+                        stationId = arrival.gtfsStopId ?: arrival.stationName,
+                        stationName = arrival.stationName,
+                        stationDisplay = arrival.stationDisplay,
+                        direction = arrival.direction,
+                        destination = DirectionHelper.getDestination(arrival.routeId, arrival.direction),
+                        generalDirection = DirectionHelper.getGeneralDirection(arrival.routeId, arrival.direction),
+                        arrivalTime = arrival.arrivalTime,
+                        distanceInMeters = arrival.distanceInMeters
                     )
                 }
-
-                // Process South-bound trains
-                for (trainData in stationData.S) {
-                    // Skip unknown routes (shuttles, express variants, etc.)
-                    if (!DirectionHelper.isValidRoute(trainData.route)) continue
-                    val arrivalTime = parseTime(trainData.time) ?: continue
-                    if (arrivalTime.isBefore(Instant.now().minusSeconds(120))) continue
-
-                    trains.add(
-                        NearbyTrain(
-                            lineId = trainData.route,
-                            stationId = stationData.id.ifEmpty { stationData.name },
-                            stationName = stationData.name,
-                            stationDisplay = stationData.name,
-                            direction = "S",
-                            destination = DirectionHelper.getDestination(trainData.route, "S"),
-                            generalDirection = DirectionHelper.getGeneralDirection(trainData.route, "S"),
-                            arrivalTime = arrivalTime,
-                            distanceInMeters = distanceInMeters
-                        )
-                    )
-                }
-            }
-
-            // Sort by arrival time
-            Result.success(trains.sortedBy { it.arrivalTime })
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching nearby trains", e)
-            Result.failure(e)
-        }
-    }
-
-    private fun parseTime(timeString: String): Instant? {
-        return try {
-            ZonedDateTime.parse(timeString, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant()
-        } catch (e: Exception) {
-            try {
-                Instant.parse(timeString)
-            } catch (e2: Exception) {
-                null
-            }
         }
     }
 }
@@ -215,7 +142,6 @@ object DirectionHelper {
         "S" to "Grand Central–42 St"
     )
 
-    // General direction by borough
     private val northBoroughs = mapOf(
         "1" to "Bronx",
         "2" to "Bronx",

--- a/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/di/AppModule.kt
+++ b/NowDepartingAndroid/app/src/main/java/com/move38/nowdeparting/di/AppModule.kt
@@ -1,18 +1,12 @@
 package com.move38.nowdeparting.di
 
-import android.content.Context
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
-import com.move38.nowdeparting.data.api.MtaApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -40,22 +34,5 @@ object AppModule {
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .build()
-    }
-
-    @Provides
-    @Singleton
-    fun provideRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit {
-        val contentType = "application/json".toMediaType()
-        return Retrofit.Builder()
-            .baseUrl(MtaApiService.BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(json.asConverterFactory(contentType))
-            .build()
-    }
-
-    @Provides
-    @Singleton
-    fun provideMtaApiService(retrofit: Retrofit): MtaApiService {
-        return retrofit.create(MtaApiService::class.java)
     }
 }


### PR DESCRIPTION
- Add GTFSRTParser.kt: custom binary protobuf decoder for GTFS-RT feeds
- Add MTAFeedConfiguration.kt: route-to-feed URL mapping for all subway lines
- Add MTAFeedService.kt: fetches binary feeds from api-endpoint.mta.info with 30s caching
- Update stations.json with gtfsStopId, latitude, longitude from iOS version
- Update Station model to include gtfsStopId, latitude, longitude fields
- Rewrite SubwayRepository to use MTAFeedService instead of wheresthefuckingtrain.com
- Simplify AppModule by removing Retrofit and MtaApiService providers

Closes #14