### PR TITLE
Closes #25 - Cleanup times view ios

### DIFF
--- a/Now Departing.xcodeproj/project.pbxproj
+++ b/Now Departing.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = NowDepartingWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NowDepartingWidget/Info.plist;
@@ -399,7 +399,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing.NowDepartingWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -419,7 +419,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = NowDepartingWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NowDepartingWidget/Info.plist;
@@ -431,7 +431,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing.NowDepartingWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -572,7 +572,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Now Departing/Now Departing.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -589,7 +589,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -607,7 +607,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Now Departing/Now Departing.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -624,7 +624,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -641,7 +641,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -657,7 +657,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -675,7 +675,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 195;
+				CURRENT_PROJECT_VERSION = 196;
 				DEVELOPMENT_TEAM = 63KWA2RPU8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -691,7 +691,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.move38.Now-Departing.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/Now Departing/FavoritesView.swift
+++ b/Now Departing/FavoritesView.swift
@@ -74,6 +74,7 @@ struct FavoritesView: View {
                     FavoriteTrainRow(
                         favorite: favorite,
                         trainData: trainDataManager.getTrainData(for: favorite),
+                        isLoaded: trainDataManager.isLoaded(for: favorite),
                         stationDataManager: stationDataManager
                     )
                 }
@@ -185,10 +186,10 @@ struct EmptyFavoritesView: View {
 struct FavoriteTrainRow: View {
     let favorite: FavoriteItem
     let trainData: [TrainArrival]?
+    let isLoaded: Bool
     let stationDataManager: StationDataManager
     @EnvironmentObject var serviceAlertsManager: ServiceAlertsManager
     @State private var currentTime = Date()
-    @State private var hasTimedOut = false
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -277,7 +278,8 @@ struct FavoriteTrainRow: View {
                                 .foregroundColor(.secondary)
                             }
                         }
-                    } else if hasTimedOut {  // ← NEW: Show "--" after timeout
+                    } else if isLoaded {
+                        // Fetch completed but no upcoming trains
                         Text("--")
                             .font(.custom("HelveticaNeue-Bold", size: 26))
                             .foregroundColor(.primary)
@@ -286,33 +288,9 @@ struct FavoriteTrainRow: View {
                             .font(.custom("HelveticaNeue", size: 14))
                             .foregroundColor(.secondary)
                     } else {
-                        // Loading state
-                        VStack(alignment: .center) {
-                            Spacer()
-                            ProgressView()
-                                .scaleEffect(1.5)
-                            Spacer()
-                        }
-                    }
-                }
-                .onAppear {  // ← NEW: Added timeout logic
-                    // Set timeout for loading state
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
-                        if trainData?.isEmpty ?? true {
-                            hasTimedOut = true
-                        }
-                    }
-                }
-                .onChange(of: trainData) { oldData, newData in
-                    if newData != nil && !newData!.isEmpty {
-                        hasTimedOut = false
-                    } else {
-                        // Data became empty (trains expired or fetch failed) — restart timeout
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
-                            if trainData?.isEmpty ?? true {
-                                hasTimedOut = true
-                            }
-                        }
+                        // First fetch still in progress
+                        ProgressView()
+                            .scaleEffect(1.5)
                     }
                 }
             }
@@ -378,6 +356,11 @@ class FavoriteTrainDataManager: ObservableObject {
         let now = Date()
         let fresh = data.filter { $0.arrivalTime.timeIntervalSince(now) > -60 }
         return fresh.isEmpty ? nil : fresh
+    }
+
+    func isLoaded(for favorite: FavoriteItem) -> Bool {
+        let key = "\(favorite.lineId)-\(favorite.stationName)-\(favorite.direction)"
+        return lastFetchTime[key] != nil
     }
     
     func fetchTrainData(for favorite: FavoriteItem) {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -485,26 +485,20 @@ struct TimesView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingServiceAlerts = true }) {
                         if serviceAlertsManager.hasActiveAlerts(for: line.id) {
-                            // Active disruption: icon + label in a yellow glass pill
+                            // Active disruption: icon + label
                             HStack(spacing: 5) {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .font(.system(size: 12, weight: .semibold))
                                 Text("Service Change")
                                     .font(.custom("HelveticaNeue-Bold", size: 13))
                             }
-                            .foregroundColor(.yellow)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial)
-                            .overlay(Capsule().stroke(Color.yellow.opacity(0.5), lineWidth: 1))
-                            .clipShape(Capsule())
                         } else {
                             // Upcoming only: bare icon
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .foregroundColor(.secondary)
                         }
                     }
-                    .buttonStyle(PlainButtonStyle())
+                    .tint(.yellow)
                 }
             }
         }

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -302,6 +302,7 @@ class TimesViewModeliOS: ObservableObject {
 struct TimesView: View {
     let line: SubwayLine
     let station: Station
+    let initialDirection: String
 
     @EnvironmentObject var favoritesManager: FavoritesManager
     @EnvironmentObject var stationDataManager: StationDataManager
@@ -309,17 +310,24 @@ struct TimesView: View {
     @StateObject private var viewModel = TimesViewModeliOS()
     @State private var direction: String
     @State private var showingServiceAlerts = false
+    @State private var arrowsVisible: Bool = false
 
     @Environment(\.dismiss) private var dismiss
 
     init(line: SubwayLine, station: Station, direction: String) {
         self.line = line
         self.station = station
+        self.initialDirection = direction
         self._direction = State(initialValue: direction)
     }
 
     private var oppositeDirection: String {
         direction == "N" ? "S" : "N"
+    }
+
+    // True once the user has toggled away from the original direction
+    private var isReversed: Bool {
+        direction != initialDirection
     }
 
     private var isFavorited: Bool {
@@ -376,9 +384,9 @@ struct TimesView: View {
                                 .font(.custom("HelveticaNeue-Bold", size: 24))
                                 .foregroundColor(.white)
 
-                            // Terminal station + reverse icon — entire row is tappable
+                            // Terminal station + direction arrows — entire row is tappable
                             Button(action: toggleDirection) {
-                                HStack(spacing: 5) {
+                                HStack(spacing: 6) {
                                     Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
                                         .font(.custom("HelveticaNeue", size: 16))
                                         .foregroundColor(.secondary)
@@ -387,9 +395,22 @@ struct TimesView: View {
                                             insertion: .opacity.combined(with: .offset(x: 0, y: 8)),
                                             removal: .opacity.combined(with: .offset(x: 0, y: -8))
                                         ))
-                                    Image(systemName: "arrow.triangle.2.circlepath")
-                                        .font(.system(size: 12, weight: .medium))
-                                        .foregroundColor(.secondary)
+                                    // ← → arrows: the active direction's arrow is white, the other dimmed
+                                    HStack(spacing: 1) {
+                                        Image(systemName: "arrow.left")
+                                            .font(.system(size: 12, weight: .semibold))
+                                            .foregroundColor(isReversed ? .white : Color(white: 1, opacity: 0.25))
+                                        Image(systemName: "arrow.right")
+                                            .font(.system(size: 12, weight: .semibold))
+                                            .foregroundColor(isReversed ? Color(white: 1, opacity: 0.25) : .white)
+                                    }
+                                    .opacity(arrowsVisible ? 1 : 0)
+                                    .scaleEffect(arrowsVisible ? 1 : 0.5, anchor: .leading)
+                                    .onAppear {
+                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.65).delay(0.2)) {
+                                            arrowsVisible = true
+                                        }
+                                    }
                                 }
                             }
                             .buttonStyle(PlainButtonStyle())
@@ -491,6 +512,7 @@ struct TimesView: View {
             viewModel.startFetchingTimes(for: line, station: station, direction: direction)
             serviceAlertsManager.fetchAlerts()
             if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
+                LiveActivityManager.shared.endActivity() // ensure only one activity at a time
                 startLiveActivity()
             }
         }

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -391,7 +391,7 @@ struct TimesView: View {
                         Spacer()
                     }
                     .padding(.horizontal, 24)
-                    .padding(.top, 20)
+                    .padding(.top, 48)
 
                     // Train times — re-keyed on direction so the whole block transitions on toggle
                     VStack(spacing: 12) {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -391,7 +391,7 @@ struct TimesView: View {
                         Spacer()
                     }
                     .padding(.horizontal, 24)
-                    .padding(.top, 8)
+                    .padding(.top, 20)
 
                     // Train times — re-keyed on direction so the whole block transitions on toggle
                     VStack(spacing: 12) {
@@ -417,12 +417,9 @@ struct TimesView: View {
                                     .foregroundColor(.white)
 
                                 if viewModel.nextTrains.count > 1 {
-                                    HStack(spacing: 6) {
-                                        Text("next trains")
-                                        Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
-                                            getAdditionalTimeText(for: train)
-                                        }.joined(separator: ", "))
-                                    }
+                                    Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
+                                        getAdditionalTimeText(for: train)
+                                    }.joined(separator: ", "))
                                     .font(.custom("HelveticaNeue", size: 20))
                                     .foregroundColor(.secondary)
                                 }
@@ -437,33 +434,6 @@ struct TimesView: View {
                     .padding(.horizontal, 24)
 
                     Spacer(minLength: 40)
-
-                    // Service alert banner — yellow if active now, grey if only upcoming
-                    if serviceAlertsManager.hasAlerts(for: line.id) {
-                        let isActive = serviceAlertsManager.hasActiveAlerts(for: line.id)
-                        Button(action: { showingServiceAlerts = true }) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .foregroundColor(isActive ? .yellow : .secondary)
-                                Text(isActive ? "Service Change" : "Planned Service Changes")
-                                    .font(.custom("HelveticaNeue-Bold", size: 15))
-                                    .foregroundColor(isActive ? .yellow : .secondary)
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 13, weight: .semibold))
-                                    .foregroundColor(isActive ? .yellow.opacity(0.7) : .secondary.opacity(0.7))
-                            }
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 12)
-                            .background(isActive ? Color.yellow.opacity(0.15) : Color.secondary.opacity(0.1))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(isActive ? Color.yellow.opacity(0.4) : Color.secondary.opacity(0.25), lineWidth: 1)
-                            )
-                            .cornerRadius(12)
-                        }
-                        .padding(.horizontal, 24)
-                    }
 
                     // Action buttons
                     VStack(spacing: 12) {
@@ -511,6 +481,16 @@ struct TimesView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.black, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            if serviceAlertsManager.hasAlerts(for: line.id) {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showingServiceAlerts = true }) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(serviceAlertsManager.hasActiveAlerts(for: line.id) ? .yellow : .secondary)
+                    }
+                }
+            }
+        }
         .onAppear {
             viewModel.startFetchingTimes(for: line, station: station, direction: direction)
             serviceAlertsManager.fetchAlerts()

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -400,14 +400,13 @@ struct TimesView: View {
                                 .scaleEffect(1.5)
                                 .padding(.vertical, 48)
                         } else if !viewModel.errorMessage.isEmpty {
-                            VStack(spacing: 8) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .font(.system(size: 40))
-                                    .foregroundColor(.orange)
-                                Text(viewModel.errorMessage)
-                                    .font(.custom("HelveticaNeue", size: 14))
+                            VStack(spacing: 12) {
+                                Text("--")
+                                    .font(.custom("HelveticaNeue-Bold", size: 80))
+                                    .foregroundColor(.white)
+                                Text("No trains")
+                                    .font(.custom("HelveticaNeue-Bold", size: 20))
                                     .foregroundColor(.secondary)
-                                    .multilineTextAlignment(.center)
                             }
                             .padding(.vertical, 48)
                         } else if !viewModel.nextTrains.isEmpty {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -230,6 +230,7 @@ class TimesViewModeliOS: ObservableObject {
     private var apiTimer: Timer?
     private var displayTimer: Timer?
     private var arrivalTimes: [Date] = []
+    private var fetchGeneration: Int = 0
 
     func startFetchingTimes(for line: SubwayLine, station: Station, direction: String) {
         loading = true
@@ -254,6 +255,7 @@ class TimesViewModeliOS: ObservableObject {
     }
 
     func clearTimes() {
+        fetchGeneration += 1  // invalidate any in-flight fetch
         arrivalTimes = []
         nextTrains = []
         errorMessage = ""
@@ -278,12 +280,13 @@ class TimesViewModeliOS: ObservableObject {
     }
 
     private func fetchArrivalTimes(for line: SubwayLine, station: Station, direction: String) {
+        let generation = fetchGeneration
         MTAFeedService.shared.fetchArrivals(
             routeId: line.id,
             station: station,
             direction: direction
         ) { [weak self] result in
-            guard let self = self else { return }
+            guard let self = self, self.fetchGeneration == generation else { return }
             switch result {
             case .success(let arrivals):
                 self.arrivalTimes = arrivals

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -481,23 +481,30 @@ struct TimesView: View {
         .toolbarBackground(Color.black, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
-            // Principal: "Service Change" title when there is an active disruption
-            if serviceAlertsManager.hasActiveAlerts(for: line.id) {
-                ToolbarItem(placement: .principal) {
-                    Button(action: { showingServiceAlerts = true }) {
-                        Text("Service Change")
-                            .font(.custom("HelveticaNeue-Bold", size: 15))
-                            .foregroundColor(.yellow)
-                    }
-                }
-            }
-            // Trailing icon for any alert (active = yellow, upcoming = secondary)
             if serviceAlertsManager.hasAlerts(for: line.id) {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingServiceAlerts = true }) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(serviceAlertsManager.hasActiveAlerts(for: line.id) ? .yellow : .secondary)
+                        if serviceAlertsManager.hasActiveAlerts(for: line.id) {
+                            // Active disruption: icon + label in a yellow glass pill
+                            HStack(spacing: 5) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 12, weight: .semibold))
+                                Text("Service Change")
+                                    .font(.custom("HelveticaNeue-Bold", size: 13))
+                            }
+                            .foregroundColor(.yellow)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(.ultraThinMaterial)
+                            .overlay(Capsule().stroke(Color.yellow.opacity(0.5), lineWidth: 1))
+                            .clipShape(Capsule())
+                        } else {
+                            // Upcoming only: bare icon
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.secondary)
+                        }
                     }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
         }

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -253,6 +253,13 @@ class TimesViewModeliOS: ObservableObject {
         displayTimer = nil
     }
 
+    func clearTimes() {
+        arrivalTimes = []
+        nextTrains = []
+        errorMessage = ""
+        loading = true
+    }
+
     private func updateDisplayTimes() {
         let now = Date()
         nextTrains = arrivalTimes.compactMap { arrivalTime in
@@ -301,8 +308,6 @@ struct TimesView: View {
     @EnvironmentObject var serviceAlertsManager: ServiceAlertsManager
     @StateObject private var viewModel = TimesViewModeliOS()
     @State private var direction: String
-    @State private var showingLiveActivityInfo = false
-    @State private var liveActivityStarted = false
     @State private var showingServiceAlerts = false
 
     @Environment(\.dismiss) private var dismiss
@@ -358,7 +363,7 @@ struct TimesView: View {
                         .padding(.horizontal, 24)
                     }
 
-                    // Header: line badge + station + direction terminal
+                    // Header: line badge + station name + inline direction button
                     HStack(alignment: .top, spacing: 12) {
                         Text(line.label)
                             .font(.custom("HelveticaNeue-Bold", size: 50))
@@ -370,47 +375,71 @@ struct TimesView: View {
                             Text(station.display)
                                 .font(.custom("HelveticaNeue-Bold", size: 24))
                                 .foregroundColor(.white)
-                            Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
-                                .font(.custom("HelveticaNeue", size: 16))
-                                .foregroundColor(.secondary)
+
+                            // Terminal station + reverse icon — entire row is tappable
+                            Button(action: toggleDirection) {
+                                HStack(spacing: 5) {
+                                    Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
+                                        .font(.custom("HelveticaNeue", size: 16))
+                                        .foregroundColor(.secondary)
+                                        .id("terminal-\(direction)")
+                                        .transition(.asymmetric(
+                                            insertion: .opacity.combined(with: .offset(x: 0, y: 8)),
+                                            removal: .opacity.combined(with: .offset(x: 0, y: -8))
+                                        ))
+                                    Image(systemName: "arrow.triangle.2.circlepath")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            .buttonStyle(PlainButtonStyle())
                         }
                         Spacer()
                     }
                     .padding(.horizontal, 24)
                     .padding(.top, 8)
 
-                    // Train times
-                    if viewModel.loading && viewModel.nextTrains.isEmpty {
-                        ProgressView()
-                            .scaleEffect(1.5)
+                    // Train times — re-keyed on direction so the whole block transitions on toggle
+                    VStack(spacing: 12) {
+                        if viewModel.loading && viewModel.nextTrains.isEmpty {
+                            ProgressView()
+                                .scaleEffect(1.5)
+                                .padding(.vertical, 48)
+                        } else if !viewModel.errorMessage.isEmpty {
+                            VStack(spacing: 8) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 40))
+                                    .foregroundColor(.orange)
+                                Text(viewModel.errorMessage)
+                                    .font(.custom("HelveticaNeue", size: 14))
+                                    .foregroundColor(.secondary)
+                                    .multilineTextAlignment(.center)
+                            }
                             .padding(.vertical, 48)
-                    } else if !viewModel.errorMessage.isEmpty {
-                        VStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.system(size: 40))
-                                .foregroundColor(.orange)
-                            Text(viewModel.errorMessage)
-                                .font(.custom("HelveticaNeue", size: 14))
-                                .foregroundColor(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
-                        .padding(.vertical, 48)
-                    } else if !viewModel.nextTrains.isEmpty {
-                        VStack(spacing: 12) {
-                            Text(getTimeText(for: viewModel.nextTrains[0]))
-                                .font(.custom("HelveticaNeue-Bold", size: 80))
-                                .foregroundColor(.white)
+                        } else if !viewModel.nextTrains.isEmpty {
+                            VStack(spacing: 12) {
+                                Text(getTimeText(for: viewModel.nextTrains[0]))
+                                    .font(.custom("HelveticaNeue-Bold", size: 80))
+                                    .foregroundColor(.white)
 
-                            if viewModel.nextTrains.count > 1 {
-                                Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
-                                    getAdditionalTimeText(for: train)
-                                }.joined(separator: ", "))
-                                .font(.custom("HelveticaNeue", size: 20))
-                                .foregroundColor(.secondary)
+                                if viewModel.nextTrains.count > 1 {
+                                    Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
+                                        getAdditionalTimeText(for: train)
+                                    }.joined(separator: ", "))
+                                    .font(.custom("HelveticaNeue", size: 20))
+                                    .foregroundColor(.secondary)
+                                }
                             }
                         }
-                        .padding(.horizontal, 24)
                     }
+                    .id("times-\(direction)")
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .offset(x: 0, y: 20)),
+                        removal: .opacity.combined(with: .offset(x: 0, y: -20))
+                    ))
+                    .padding(.horizontal, 24)
+
+                    Spacer(minLength: 40)
 
                     // Action buttons
                     VStack(spacing: 12) {
@@ -449,25 +478,6 @@ struct TimesView: View {
                             )
                             .cornerRadius(14)
                         }
-
-                        if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
-                            Button(action: { toggleLiveActivity() }) {
-                                HStack(spacing: 8) {
-                                    Image(systemName: liveActivityStarted ? "iphone.gen3.radiowaves.left.and.right" : "iphone.gen3")
-                                    Text(liveActivityStarted ? "Stop Live Activity" : "Start Live Activity")
-                                }
-                                .font(.custom("HelveticaNeue-Bold", size: 18))
-                                .foregroundColor(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 16)
-                                .background(.ultraThinMaterial)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 14)
-                                        .stroke(liveActivityStarted ? Color.red.opacity(0.5) : Color.white.opacity(0.2), lineWidth: 1)
-                                )
-                                .cornerRadius(14)
-                            }
-                        }
                     }
                     .padding(.horizontal, 24)
                     .padding(.bottom, 40)
@@ -477,40 +487,19 @@ struct TimesView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.black, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                HStack(spacing: 8) {
-                    Text(line.label)
-                        .font(.custom("HelveticaNeue-Bold", size: 22))
-                        .foregroundColor(line.fg_color)
-                        .frame(width: 34, height: 34)
-                        .background(Circle().fill(line.bg_color))
-                    Text(station.display)
-                        .font(.custom("HelveticaNeue-Bold", size: 16))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                }
-            }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: toggleDirection) {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(.white)
-                }
-            }
-        }
         .onAppear {
             viewModel.startFetchingTimes(for: line, station: station, direction: direction)
             serviceAlertsManager.fetchAlerts()
+            if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
+                startLiveActivity()
+            }
         }
         .onChange(of: direction) { newDirection in
             viewModel.stopFetchingTimes()
             viewModel.startFetchingTimes(for: line, station: station, direction: newDirection)
-            if liveActivityStarted {
-                if #available(iOS 16.2, *) {
-                    LiveActivityManager.shared.endActivity()
-                }
-                liveActivityStarted = false
+            if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
+                LiveActivityManager.shared.endActivity()
+                startLiveActivity()
             }
         }
         .sheet(isPresented: $showingServiceAlerts) {
@@ -518,40 +507,25 @@ struct TimesView: View {
         }
         .onDisappear {
             viewModel.stopFetchingTimes()
-            if liveActivityStarted {
-                if #available(iOS 16.2, *) {
-                    LiveActivityManager.shared.endActivity()
-                }
-                liveActivityStarted = false
+            if #available(iOS 16.2, *) {
+                LiveActivityManager.shared.endActivity()
             }
         }
         .onReceive(viewModel.$nextTrains) { trains in
-            if liveActivityStarted && !trains.isEmpty {
-                if #available(iOS 16.2, *) {
+            if !trains.isEmpty {
+                if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
                     LiveActivityManager.shared.updateActivity(nextTrains: trains)
                 }
             }
-        }
-        .alert("Live Activity for StandBy", isPresented: $showingLiveActivityInfo) {
-            Button("Got It", role: .cancel) {}
-        } message: {
-            Text("Live Activity started! Place your iPhone horizontally on a charger to see it in StandBy mode.\n\nThe display will show real-time train arrivals and automatically update.")
         }
     }
 
     private func toggleDirection() {
         let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
         impactFeedback.impactOccurred()
-        direction = oppositeDirection
-    }
-
-    @available(iOS 16.2, *)
-    private func toggleLiveActivity() {
-        if liveActivityStarted {
-            LiveActivityManager.shared.endActivity()
-            liveActivityStarted = false
-        } else {
-            startLiveActivity()
+        withAnimation(.easeInOut(duration: 0.3)) {
+            viewModel.clearTimes()
+            direction = oppositeDirection
         }
     }
 
@@ -583,12 +557,6 @@ struct TimesView: View {
             destinationStation: destinationStation,
             nextTrains: viewModel.nextTrains
         )
-
-        liveActivityStarted = true
-        showingLiveActivityInfo = true
-
-        let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-        impactFeedback.impactOccurred()
     }
 
     private func getTimeText(for train: (minutes: Int, seconds: Int)) -> String {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -344,33 +344,6 @@ struct TimesView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Service alert banner — yellow if active now, grey if only upcoming
-                    if serviceAlertsManager.hasAlerts(for: line.id) {
-                        let isActive = serviceAlertsManager.hasActiveAlerts(for: line.id)
-                        Button(action: { showingServiceAlerts = true }) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .foregroundColor(isActive ? .yellow : .secondary)
-                                Text(isActive ? "Service Change" : "Planned Service Changes")
-                                    .font(.custom("HelveticaNeue-Bold", size: 15))
-                                    .foregroundColor(isActive ? .yellow : .secondary)
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 13, weight: .semibold))
-                                    .foregroundColor(isActive ? .yellow.opacity(0.7) : .secondary.opacity(0.7))
-                            }
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 12)
-                            .background(isActive ? Color.yellow.opacity(0.15) : Color.secondary.opacity(0.1))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(isActive ? Color.yellow.opacity(0.4) : Color.secondary.opacity(0.25), lineWidth: 1)
-                            )
-                            .cornerRadius(12)
-                        }
-                        .padding(.horizontal, 24)
-                    }
-
                     // Header: line badge + station name + inline direction button
                     HStack(alignment: .top, spacing: 12) {
                         Text(line.label)
@@ -381,7 +354,7 @@ struct TimesView: View {
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text(station.display)
-                                .font(.custom("HelveticaNeue-Bold", size: 24))
+                                .font(.custom("HelveticaNeue-Bold", size: 28))
                                 .foregroundColor(.white)
 
                             // Terminal station + direction arrows — entire row is tappable
@@ -444,9 +417,12 @@ struct TimesView: View {
                                     .foregroundColor(.white)
 
                                 if viewModel.nextTrains.count > 1 {
-                                    Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
-                                        getAdditionalTimeText(for: train)
-                                    }.joined(separator: ", "))
+                                    HStack(spacing: 6) {
+                                        Text("next trains")
+                                        Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
+                                            getAdditionalTimeText(for: train)
+                                        }.joined(separator: ", "))
+                                    }
                                     .font(.custom("HelveticaNeue", size: 20))
                                     .foregroundColor(.secondary)
                                 }
@@ -461,6 +437,33 @@ struct TimesView: View {
                     .padding(.horizontal, 24)
 
                     Spacer(minLength: 40)
+
+                    // Service alert banner — yellow if active now, grey if only upcoming
+                    if serviceAlertsManager.hasAlerts(for: line.id) {
+                        let isActive = serviceAlertsManager.hasActiveAlerts(for: line.id)
+                        Button(action: { showingServiceAlerts = true }) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundColor(isActive ? .yellow : .secondary)
+                                Text(isActive ? "Service Change" : "Planned Service Changes")
+                                    .font(.custom("HelveticaNeue-Bold", size: 15))
+                                    .foregroundColor(isActive ? .yellow : .secondary)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(isActive ? .yellow.opacity(0.7) : .secondary.opacity(0.7))
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                            .background(isActive ? Color.yellow.opacity(0.15) : Color.secondary.opacity(0.1))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(isActive ? Color.yellow.opacity(0.4) : Color.secondary.opacity(0.25), lineWidth: 1)
+                            )
+                            .cornerRadius(12)
+                        }
+                        .padding(.horizontal, 24)
+                    }
 
                     // Action buttons
                     VStack(spacing: 12) {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -482,6 +482,17 @@ struct TimesView: View {
         .toolbarBackground(Color.black, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
+            // Principal: "Service Change" title when there is an active disruption
+            if serviceAlertsManager.hasActiveAlerts(for: line.id) {
+                ToolbarItem(placement: .principal) {
+                    Button(action: { showingServiceAlerts = true }) {
+                        Text("Service Change")
+                            .font(.custom("HelveticaNeue-Bold", size: 15))
+                            .foregroundColor(.yellow)
+                    }
+                }
+            }
+            // Trailing icon for any alert (active = yellow, upcoming = secondary)
             if serviceAlertsManager.hasAlerts(for: line.id) {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingServiceAlerts = true }) {

--- a/Now Departing/LinesBrowseView.swift
+++ b/Now Departing/LinesBrowseView.swift
@@ -295,31 +295,28 @@ class TimesViewModeliOS: ObservableObject {
 struct TimesView: View {
     let line: SubwayLine
     let station: Station
-    let direction: String
 
     @EnvironmentObject var favoritesManager: FavoritesManager
     @EnvironmentObject var stationDataManager: StationDataManager
     @EnvironmentObject var serviceAlertsManager: ServiceAlertsManager
     @StateObject private var viewModel = TimesViewModeliOS()
-    @State private var showingFavoriteAlert = false
+    @State private var direction: String
     @State private var showingLiveActivityInfo = false
     @State private var liveActivityStarted = false
     @State private var showingServiceAlerts = false
-    @State private var currentTime = Date()
-    @State private var widgetSize: WidgetSize = .large
 
-    // Make navigationState optional - only exists when navigating from LinesBrowseView
     @Environment(\.dismiss) private var dismiss
 
-    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
-    enum WidgetSize: String, CaseIterable {
-        case small = "Small"
-        case medium = "Medium"
-        case large = "Large"
+    init(line: SubwayLine, station: Station, direction: String) {
+        self.line = line
+        self.station = station
+        self._direction = State(initialValue: direction)
     }
 
-    // Check if this is already favorited
+    private var oppositeDirection: String {
+        direction == "N" ? "S" : "N"
+    }
+
     private var isFavorited: Bool {
         favoritesManager.isFavorite(
             lineId: line.id,
@@ -329,130 +326,98 @@ struct TimesView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                // Widget size picker with SF Symbols
-                Picker("Widget Size", selection: $widgetSize) {
-                    Image(systemName: "widget.small")
-                        .tag(WidgetSize.small)
-                    Image(systemName: "widget.medium")
-                        .tag(WidgetSize.medium)
-                    Image(systemName: "widget.large")
-                        .tag(WidgetSize.large)
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 24)
-                .padding(.top, 20)
+        ZStack {
+            Color.black.ignoresSafeArea()
 
-                // Service alert banner — yellow if active now, grey if only upcoming
-                if serviceAlertsManager.hasAlerts(for: line.id) {
-                    let isActive = serviceAlertsManager.hasActiveAlerts(for: line.id)
-                    Button(action: { showingServiceAlerts = true }) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundColor(isActive ? .yellow : .secondary)
-                            Text(isActive ? "Service Change" : "Planned Service Changes")
-                                .font(.custom("HelveticaNeue-Bold", size: 15))
-                                .foregroundColor(isActive ? .yellow : .secondary)
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(isActive ? .yellow.opacity(0.7) : .secondary.opacity(0.7))
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Service alert banner — yellow if active now, grey if only upcoming
+                    if serviceAlertsManager.hasAlerts(for: line.id) {
+                        let isActive = serviceAlertsManager.hasActiveAlerts(for: line.id)
+                        Button(action: { showingServiceAlerts = true }) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundColor(isActive ? .yellow : .secondary)
+                                Text(isActive ? "Service Change" : "Planned Service Changes")
+                                    .font(.custom("HelveticaNeue-Bold", size: 15))
+                                    .foregroundColor(isActive ? .yellow : .secondary)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(isActive ? .yellow.opacity(0.7) : .secondary.opacity(0.7))
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                            .background(isActive ? Color.yellow.opacity(0.15) : Color.secondary.opacity(0.1))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(isActive ? Color.yellow.opacity(0.4) : Color.secondary.opacity(0.25), lineWidth: 1)
+                            )
+                            .cornerRadius(12)
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .background(isActive ? Color.yellow.opacity(0.15) : Color.secondary.opacity(0.1))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(isActive ? Color.yellow.opacity(0.4) : Color.secondary.opacity(0.25), lineWidth: 1)
-                        )
-                        .cornerRadius(12)
+                        .padding(.horizontal, 24)
+                    }
+
+                    // Header: line badge + station + direction terminal
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(line.label)
+                            .font(.custom("HelveticaNeue-Bold", size: 50))
+                            .foregroundColor(line.fg_color)
+                            .frame(width: 72, height: 72)
+                            .background(Circle().fill(line.bg_color))
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(station.display)
+                                .font(.custom("HelveticaNeue-Bold", size: 24))
+                                .foregroundColor(.white)
+                            Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
+                                .font(.custom("HelveticaNeue", size: 16))
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
                     }
                     .padding(.horizontal, 24)
-                }
+                    .padding(.top, 8)
 
-                // Widget preview container with centered content
-                ZStack {
-                    // Glass/frosted background
-                    RoundedRectangle(cornerRadius: widgetCornerRadius)
-                        .fill(.ultraThinMaterial)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: widgetCornerRadius)
-                                .stroke(Color.white.opacity(0.2), lineWidth: 1)
-                        )
-                        .shadow(color: Color.black.opacity(0.2), radius: 12, x: 0, y: 6)
-
-                    // Widget content
-                    switch widgetSize {
-                    case .small:
-                        smallWidgetContent
-                    case .medium:
-                        mediumWidgetContent
-                    case .large:
-                        largeWidgetContent
-                    }
-                }
-                .frame(width: widgetWidth, height: widgetHeight)
-                .aspectRatio(widgetSize == .small ? 1 : nil, contentMode: .fit)
-                .animation(.easeInOut(duration: 0.3), value: widgetSize)
-                .frame(maxWidth: .infinity) // Center the widget
-                .padding(.horizontal, 24)
-
-                // Action buttons with glass effect
-                VStack(spacing: 12) {
-
-                    // Get Directions button
-                    Button(action: {
-                        openDirectionsToStation()
-                    }) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "map.fill")
-                            Text("Get Directions")
+                    // Train times
+                    if viewModel.loading && viewModel.nextTrains.isEmpty {
+                        ProgressView()
+                            .scaleEffect(1.5)
+                            .padding(.vertical, 48)
+                    } else if !viewModel.errorMessage.isEmpty {
+                        VStack(spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 40))
+                                .foregroundColor(.orange)
+                            Text(viewModel.errorMessage)
+                                .font(.custom("HelveticaNeue", size: 14))
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
                         }
-                        .font(.custom("HelveticaNeue-Bold", size: 18))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(.ultraThinMaterial)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 14)
-                                .stroke(Color.white.opacity(0.2), lineWidth: 1)
-                        )
-                        .cornerRadius(14)
+                        .padding(.vertical, 48)
+                    } else if !viewModel.nextTrains.isEmpty {
+                        VStack(spacing: 12) {
+                            Text(getTimeText(for: viewModel.nextTrains[0]))
+                                .font(.custom("HelveticaNeue-Bold", size: 80))
+                                .foregroundColor(.white)
+
+                            if viewModel.nextTrains.count > 1 {
+                                Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
+                                    getAdditionalTimeText(for: train)
+                                }.joined(separator: ", "))
+                                .font(.custom("HelveticaNeue", size: 20))
+                                .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.horizontal, 24)
                     }
 
-                    // Favorite button
-                    Button(action: {
-                        if isFavorited {
-                            removeFavorite()
-                        } else {
-                            addToFavorites()
-                        }
-                    }) {
-                        HStack(spacing: 8) {
-                            Image(systemName: isFavorited ? "heart.fill" : "heart")
-                            Text(isFavorited ? "Remove from Favorites" : "Add to Favorites")
-                        }
-                        .font(.custom("HelveticaNeue-Bold", size: 18))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(.ultraThinMaterial)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 14)
-                                .stroke(isFavorited ? Color.red.opacity(0.5) : Color.white.opacity(0.2), lineWidth: 1)
-                        )
-                        .cornerRadius(14)
-                    }
-
-                    // Live Activity for StandBy mode button
-                    if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
-                        Button(action: {
-                            toggleLiveActivity()
-                        }) {
+                    // Action buttons
+                    VStack(spacing: 12) {
+                        Button(action: { openDirectionsToStation() }) {
                             HStack(spacing: 8) {
-                                Image(systemName: liveActivityStarted ? "iphone.gen3.radiowaves.left.and.right" : "iphone.gen3")
-                                Text(liveActivityStarted ? "Stop Live Activity" : "Start Live Activity")
+                                Image(systemName: "map.fill")
+                                Text("Get Directions")
                             }
                             .font(.custom("HelveticaNeue-Bold", size: 18))
                             .foregroundColor(.white)
@@ -461,28 +426,86 @@ struct TimesView: View {
                             .background(.ultraThinMaterial)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 14)
-                                    .stroke(liveActivityStarted ? Color.red.opacity(0.5) : Color.white.opacity(0.2), lineWidth: 1)
+                                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
                             )
                             .cornerRadius(14)
                         }
+
+                        Button(action: {
+                            if isFavorited { removeFavorite() } else { addToFavorites() }
+                        }) {
+                            HStack(spacing: 8) {
+                                Image(systemName: isFavorited ? "heart.fill" : "heart")
+                                Text(isFavorited ? "Remove from Favorites" : "Add to Favorites")
+                            }
+                            .font(.custom("HelveticaNeue-Bold", size: 18))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(.ultraThinMaterial)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 14)
+                                    .stroke(isFavorited ? Color.red.opacity(0.5) : Color.white.opacity(0.2), lineWidth: 1)
+                            )
+                            .cornerRadius(14)
+                        }
+
+                        if #available(iOS 16.2, *), LiveActivityManager.isSupported() {
+                            Button(action: { toggleLiveActivity() }) {
+                                HStack(spacing: 8) {
+                                    Image(systemName: liveActivityStarted ? "iphone.gen3.radiowaves.left.and.right" : "iphone.gen3")
+                                    Text(liveActivityStarted ? "Stop Live Activity" : "Start Live Activity")
+                                }
+                                .font(.custom("HelveticaNeue-Bold", size: 18))
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(.ultraThinMaterial)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 14)
+                                        .stroke(liveActivityStarted ? Color.red.opacity(0.5) : Color.white.opacity(0.2), lineWidth: 1)
+                                )
+                                .cornerRadius(14)
+                            }
+                        }
                     }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 40)
                 }
-                .padding(.horizontal, 24)
-                .padding(.bottom, 40)
             }
         }
-        .background(Color(UIColor.systemGroupedBackground))
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                HStack(spacing: 8) {
+                    Text(line.label)
+                        .font(.custom("HelveticaNeue-Bold", size: 22))
+                        .foregroundColor(line.fg_color)
+                        .frame(width: 34, height: 34)
+                        .background(Circle().fill(line.bg_color))
+                    Text(station.display)
+                        .font(.custom("HelveticaNeue-Bold", size: 16))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: toggleDirection) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+            }
+        }
         .onAppear {
             viewModel.startFetchingTimes(for: line, station: station, direction: direction)
             serviceAlertsManager.fetchAlerts()
         }
-        .sheet(isPresented: $showingServiceAlerts) {
-            ServiceAlertsSheet(alerts: serviceAlertsManager.alerts(for: line.id), line: line)
-        }
-        .onDisappear {
+        .onChange(of: direction) { newDirection in
             viewModel.stopFetchingTimes()
-            // Stop Live Activity when leaving the view
+            viewModel.startFetchingTimes(for: line, station: station, direction: newDirection)
             if liveActivityStarted {
                 if #available(iOS 16.2, *) {
                     LiveActivityManager.shared.endActivity()
@@ -490,11 +513,19 @@ struct TimesView: View {
                 liveActivityStarted = false
             }
         }
-        .onReceive(timer) { time in
-            currentTime = time
+        .sheet(isPresented: $showingServiceAlerts) {
+            ServiceAlertsSheet(alerts: serviceAlertsManager.alerts(for: line.id), line: line)
+        }
+        .onDisappear {
+            viewModel.stopFetchingTimes()
+            if liveActivityStarted {
+                if #available(iOS 16.2, *) {
+                    LiveActivityManager.shared.endActivity()
+                }
+                liveActivityStarted = false
+            }
         }
         .onReceive(viewModel.$nextTrains) { trains in
-            // Update Live Activity when train times change
             if liveActivityStarted && !trains.isEmpty {
                 if #available(iOS 16.2, *) {
                     LiveActivityManager.shared.updateActivity(nextTrains: trains)
@@ -506,10 +537,13 @@ struct TimesView: View {
         } message: {
             Text("Live Activity started! Place your iPhone horizontally on a charger to see it in StandBy mode.\n\nThe display will show real-time train arrivals and automatically update.")
         }
-        // Removed confirmation dialog - favorites now work with single tap
     }
 
-    // MARK: - Live Activity Functions
+    private func toggleDirection() {
+        let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
+        impactFeedback.impactOccurred()
+        direction = oppositeDirection
+    }
 
     @available(iOS 16.2, *)
     private func toggleLiveActivity() {
@@ -555,233 +589,6 @@ struct TimesView: View {
 
         let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
         impactFeedback.impactOccurred()
-    }
-
-    private var widgetCornerRadius: CGFloat {
-        switch widgetSize {
-        case .small: return 20
-        case .medium: return 20
-        case .large: return 24
-        }
-    }
-
-    private var widgetWidth: CGFloat {
-        switch widgetSize {
-        case .small: return 160
-        case .medium: return 338
-        case .large: return 338
-        }
-    }
-
-    private var widgetHeight: CGFloat {
-        switch widgetSize {
-        case .small: return 160
-        case .medium: return 160
-        case .large: return 340
-        }
-    }
-
-    // Small widget - compact view with directional background
-    private var smallWidgetContent: some View {
-        ZStack {
-            // Directional background shape
-            DirectionalBackground(direction: direction, lineColor: line.bg_color)
-
-            VStack(spacing: 4) {
-                // Top row: Line badge and updated time
-                HStack {
-                    Text(line.label)
-                        .font(.custom("HelveticaNeue-Bold", size: 28))
-                        .foregroundColor(line.fg_color)
-                        .frame(width: 44, height: 44)
-                        .background(Circle().fill(line.bg_color))
-
-                    Spacer()
-                }
-
-                // Center: Train time
-                if viewModel.loading && viewModel.nextTrains.isEmpty {
-                    ProgressView()
-                } else if !viewModel.errorMessage.isEmpty {
-                    Text("--")
-                        .font(.custom("HelveticaNeue-Bold", size: 28))
-                        .foregroundColor(.primary)
-                } else if !viewModel.nextTrains.isEmpty {
-                    Text(getTimeText(for: viewModel.nextTrains[0]))
-                        .font(.custom("HelveticaNeue-Bold", size: 28))
-                        .foregroundColor(.primary)
-                    
-                    if viewModel.nextTrains.count > 1 {
-                        Text(viewModel.nextTrains.dropFirst().prefix(2).map { train in
-                            getAdditionalTimeText(for: train)
-                        }.joined(separator: ", "))
-                        .font(.custom("HelveticaNeue", size: 14))
-                        .foregroundColor(.secondary)
-                    }
-                }
-
-                // Bottom: Station name
-                Text(station.display)
-                    .font(.custom("HelveticaNeue-Bold", size: 14))
-                    .foregroundColor(.primary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity)
-            }
-            .padding(16)
-        }
-    }
-
-    // Directional background shape for small widget
-    private struct DirectionalBackground: View {
-        let direction: String
-        let lineColor: Color
-
-        var body: some View {
-            GeometryReader { geometry in
-                Path { path in
-                    let width = geometry.size.width
-                    let height = geometry.size.height
-
-                    if direction == "N" {
-                        // Northbound - curve at top
-                        path.move(to: CGPoint(x: 0, y: height * 0.3))
-                        path.addQuadCurve(
-                            to: CGPoint(x: width, y: height * 0.3),
-                            control: CGPoint(x: width / 2, y: 0)
-                        )
-                        path.addLine(to: CGPoint(x: width, y: height))
-                        path.addLine(to: CGPoint(x: 0, y: height))
-                        path.closeSubpath()
-                    } else {
-                        // Southbound - curve at bottom
-                        path.move(to: CGPoint(x: 0, y: 0))
-                        path.addLine(to: CGPoint(x: width, y: 0))
-                        path.addLine(to: CGPoint(x: width, y: height * 0.7))
-                        path.addQuadCurve(
-                            to: CGPoint(x: 0, y: height * 0.7),
-                            control: CGPoint(x: width / 2, y: height)
-                        )
-                        path.closeSubpath()
-                    }
-                }
-                .fill(lineColor.opacity(0.15))
-            }
-        }
-    }
-
-    // Medium widget - horizontal layout
-    private var mediumWidgetContent: some View {
-        HStack(spacing: 16) {
-            // Left side - Line and station info
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    Text(line.label)
-                        .font(.custom("HelveticaNeue-Bold", size: 32))
-                        .foregroundColor(line.fg_color)
-                        .frame(width: 48, height: 48)
-                        .background(Circle().fill(line.bg_color))
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(station.display)
-                            .font(.custom("HelveticaNeue-Bold", size: 16))
-                            .lineLimit(2)
-                        Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
-                            .font(.custom("HelveticaNeue", size: 12))
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                    }
-                }
-            }
-
-            // Right side - Train times
-            VStack(spacing: 4) {
-                if viewModel.loading && viewModel.nextTrains.isEmpty {
-                    ProgressView()
-                } else if !viewModel.errorMessage.isEmpty {
-                    Text("--")
-                        .font(.custom("HelveticaNeue-Bold", size: 28))
-                        .foregroundColor(.secondary)
-                } else if !viewModel.nextTrains.isEmpty {
-                    Text(getTimeText(for: viewModel.nextTrains[0]))
-                        .font(.custom("HelveticaNeue-Bold", size: 28))
-                        .foregroundColor(.primary)
-
-                    if viewModel.nextTrains.count > 1 {
-                        Text(viewModel.nextTrains.dropFirst().prefix(2).map { train in
-                            getAdditionalTimeText(for: train)
-                        }.joined(separator: ", "))
-                        .font(.custom("HelveticaNeue", size: 14))
-                        .foregroundColor(.secondary)
-                    }
-                }
-            }
-        }
-        .padding(20)
-    }
-
-    // Large widget - vertical layout with more info
-    private var largeWidgetContent: some View {
-        VStack(spacing: 16) {
-            // Header
-            HStack(alignment: .top, spacing: 12) {
-                Text(line.label)
-                    .font(.custom("HelveticaNeue-Bold", size: 50))
-                    .foregroundColor(line.fg_color)
-                    .frame(width: 72, height: 72)
-                    .background(Circle().fill(line.bg_color))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(station.display)
-                        .font(.custom("HelveticaNeue-Bold", size: 24))
-                    Text(DirectionHelper.getToTerminalStation(for: line.id, direction: direction, stationDataManager: stationDataManager))
-                        .font(.custom("HelveticaNeue", size: 16))
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-            }
-
-            Divider()
-
-            // Train times
-            if viewModel.loading && viewModel.nextTrains.isEmpty {
-                Spacer()
-                ProgressView()
-                    .scaleEffect(1.5)
-                Spacer()
-            } else if !viewModel.errorMessage.isEmpty {
-                Spacer()
-                VStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 40))
-                        .foregroundColor(.orange)
-                    Text(viewModel.errorMessage)
-                        .font(.custom("HelveticaNeue", size: 14))
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-                Spacer()
-            } else if !viewModel.nextTrains.isEmpty {
-                VStack(spacing: 12) {
-                    // Primary time
-                    Text(getTimeText(for: viewModel.nextTrains[0]))
-                        .font(.custom("HelveticaNeue-Bold", size: 72))
-                        .foregroundColor(.primary)
-
-                    // Additional times
-                    if viewModel.nextTrains.count > 1 {
-                        Text(viewModel.nextTrains.dropFirst().prefix(5).map { train in
-                            getAdditionalTimeText(for: train)
-                        }.joined(separator: ", "))
-                        .font(.custom("HelveticaNeue", size: 20))
-                        .foregroundColor(.secondary)
-                    }
-                }
-
-                Spacer()
-            }
-        }
-        .padding(24)
     }
 
     private func getTimeText(for train: (minutes: Int, seconds: Int)) -> String {

--- a/NowDepartingWidget/NowDepartingWidgetLiveActivity.swift
+++ b/NowDepartingWidget/NowDepartingWidgetLiveActivity.swift
@@ -30,7 +30,7 @@ struct NowDepartingWidgetLiveActivity: Widget {
                             .foregroundColor(.white)
                             .lineLimit(1)
                             .minimumScaleFactor(0.7)
-                        Text("to \(context.attributes.destinationStation)")
+                        Text(context.attributes.destinationStation)
                             .font(.system(size: 20, weight: .regular))
                             .foregroundColor(.white.opacity(0.7))
                             .lineLimit(1)
@@ -54,11 +54,8 @@ struct NowDepartingWidgetLiveActivity: Widget {
                                 .minimumScaleFactor(0.8)
                             
                             if context.state.nextTrains.count > 1 {
-                                let additionalTimes = context.state.nextTrains.dropFirst().prefix(2).map { train in
-                                    getAdditionalTimeText(for: train)
-                                }.joined(separator: ", ")
-                                Text(additionalTimes)
-                                    .font(.system(size: 24, weight: .regular))
+                                Text("next train \(getAdditionalTimeText(for: context.state.nextTrains[1]))")
+                                    .font(.system(size: 20, weight: .regular))
                                     .foregroundColor(.white.opacity(0.7))
                                     .lineLimit(1)
                             }
@@ -115,7 +112,7 @@ struct NowDepartingWidgetLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     HStack {
-                        Text("to \(context.attributes.destinationStation)")
+                        Text(context.attributes.destinationStation)
                             .font(.system(size: 13, weight: .regular))
                             .foregroundColor(.white.opacity(0.7))
                             .lineLimit(1)

--- a/NowDepartingWidget/NowDepartingWidgetLiveActivity.swift
+++ b/NowDepartingWidget/NowDepartingWidgetLiveActivity.swift
@@ -24,14 +24,14 @@ struct NowDepartingWidgetLiveActivity: Widget {
                         .frame(width: 64, height: 64)
                         .background(Circle().fill(context.attributes.lineBgColor))
 
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 0) {
                         Text(context.attributes.stationName)
                             .font(.system(size: 36, weight: .bold))
                             .foregroundColor(.white)
                             .lineLimit(1)
                             .minimumScaleFactor(0.7)
                         Text(context.attributes.destinationStation)
-                            .font(.system(size: 20, weight: .regular))
+                            .font(.system(size: 18, weight: .regular))
                             .foregroundColor(.white.opacity(0.7))
                             .lineLimit(1)
                             .minimumScaleFactor(0.8)
@@ -55,7 +55,7 @@ struct NowDepartingWidgetLiveActivity: Widget {
                             
                             if context.state.nextTrains.count > 1 {
                                 Text("next train \(getAdditionalTimeText(for: context.state.nextTrains[1]))")
-                                    .font(.system(size: 20, weight: .regular))
+                                    .font(.system(size: 12, weight: .regular))
                                     .foregroundColor(.white.opacity(0.7))
                                     .lineLimit(1)
                             }

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -94,10 +94,9 @@ class LiveActivityManager {
     // End the current Live Activity
     func endActivity() {
         guard let activity = currentActivity else { return }
-
+        currentActivity = nil  // nil synchronously so rapid re-calls and new starts are safe
         Task {
             await activity.end(nil, dismissalPolicy: .immediate)
-            currentActivity = nil
             print("✅ Live Activity ended")
         }
     }


### PR DESCRIPTION
## Times View cleanup (issue #25)

### Layout & Design
- Replaced the 3-size widget picker and card wrapper with a clean full-screen black background layout
- Removed the navigation bar title — the line badge and station name make it redundant
- Added padding above/below the main content block for breathing room
- Removed the "Next Trains" section label
- Made "No trains scheduled" display consistent across loading states

### Direction Toggle
- Added an inline ←→ arrow indicator next to the terminal station name
- Arrows animate in on appear with a spring animation
- Active direction arrow is white; the other is dimmed
- Tapping the destination label or arrows toggles direction with a smooth animated transition (old terminal/times slide out, new ones slide in)
- Haptic feedback on toggle

### Service Alerts
- Moved service alert indicator to the navigation bar trailing position
- Active disruptions show a yellow "⚠ Service Change" button using the system's native liquid glass styling with `.tint(.yellow)`
- Upcoming (non-active) alerts show a subtle secondary icon only

### Live Activity
- Auto-starts a Live Activity when the Times View opens; auto-stops on dismiss
- Direction toggle ends the current activity and starts a new one for the new direction
- Fixed: stale in-flight API responses for the old direction could update the Live Activity — added a generation counter to discard them
- Fixed: `currentActivity = nil` was inside an async `Task`, causing two rapid `endActivity()` calls to both enqueue separate end tasks; the first to complete would wipe the new activity's reference, breaking all subsequent updates — moved the nil assignment to be synchronous

### Favorites
- Removed the artificial 10-second timeout that delayed showing results in the Favorites tab — replaced with an `isLoaded` flag driven by actual fetch completion